### PR TITLE
Added linux cleanup for machine-id to regenerate it on VM startup

### DIFF
--- a/playbooks/roles/cleanup/tasks/linux.yml
+++ b/playbooks/roles/cleanup/tasks/linux.yml
@@ -31,3 +31,9 @@
   poll: 30
   tags:
     - vm_only
+
+- name: Reset the machine-id which is used for DHCP IP assign
+  become: true
+  copy:
+    content: ''
+    dest: /etc/machine-id


### PR DESCRIPTION
## Description

It seems that vmware dhcp will gladly give the leased IP to another machine if it will have the same machine-id (systemd uses for dhcp client request), so it needs to be cleaned up before wrapping the image to not cause same IP use in parallel execution.

## Related Issue

fixes: #16 

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

