### PR TITLE
Added OpenSSH for Windows and AWS init scripts for keys

### DIFF
--- a/init/aws/winserver2019_init_userdata.txt
+++ b/init/aws/winserver2019_init_userdata.txt
@@ -38,10 +38,58 @@ cmd.exe /c sc config winrm start= auto
 cmd.exe /c net start winrm
 
 
+#
 # Run EC2Launch on each boot to regenerate the Administrator password
+#
 C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -SchedulePerBoot
 
 # Set LaunchConfig.json to read only to not allow ECLaunch to change "adminPasswordType" to "DoNothing"
 Set-ItemProperty -Path C:\ProgramData\Amazon\EC2-Windows\Launch\Config\LaunchConfig.json -Name IsReadOnly -Value $true
+
+
+#
+# Download the instance SSH pubkey from AWS EC2 metadata on boot
+#
+# Create the OpenSSH download public key script
+$keyDownloadScript = @'
+#!powershell
+# Script downloads the OpenSSH pubkey from AWS EC2 instance metadata and set it
+$openSSHAuthorizedKeys = 'C:\ProgramData\ssh\administrators_authorized_keys'
+
+# Download the pubkey from ec2 metadata to key file
+$keyUrl = "http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key"
+$keyRespStream = [System.Net.WebRequest]::Create($keyUrl).GetResponse().GetResponseStream()
+$streamReader = New-Object System.IO.StreamReader $keyRespStream
+$streamReader.ReadToEnd() | Out-File -FilePath $openSSHAuthorizedKeys -Encoding ASCII
+
+# Ensure access control on authorized_keys meets the requirements
+$acl = Get-ACL -Path $openSSHAuthorizedKeys
+$acl.SetAccessRuleProtection($True, $True)
+Set-Acl -Path $openSSHAuthorizedKeys -AclObject $acl
+$acl = Get-ACL -Path $openSSHAuthorizedKeys
+$ar = New-Object System.Security.AccessControl.FileSystemAccessRule( `
+    "NT Authority\Authenticated Users", "ReadAndExecute", "Allow")
+$acl.RemoveAccessRule($ar)
+$ar = New-Object System.Security.AccessControl.FileSystemAccessRule( `
+    "BUILTIN\Administrators", "FullControl", "Allow")
+$acl.RemoveAccessRule($ar)
+$ar = New-Object System.Security.AccessControl.FileSystemAccessRule( `
+    "BUILTIN\Users", "FullControl", "Allow")
+$acl.RemoveAccessRule($ar)
+Set-Acl -Path $openSSHAuthorizedKeys -AclObject $acl
+'@
+
+$keyDownloadScript | Out-File C:\ProgramData\ssh\download_ec2_pubkey.ps1
+
+# Add SSH public key receiver from AWS EC2 MetaData upon instance startup
+$name = "Download AWS EC2 OpenSSH public key"
+$desc = "Automatically downloads the AWS EC2 instance public key to allow the Administrator access"
+
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoProfile -File C:\ProgramData\ssh\download_ec2_pubkey.ps1'
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$principal = New-ScheduledTaskPrincipal -UserId System -LogonType S4U
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries 
+
+Register-ScheduledTask -TaskName $name -Trigger $trigger -Action $action -Description $desc -Principal $principal -Settings $settings
 
 </powershell>

--- a/init/aws/winserver2022_init_userdata.yml
+++ b/init/aws/winserver2022_init_userdata.yml
@@ -4,6 +4,38 @@
 
 version: 1.0
 tasks:
+  # Create the OpenSSH download public key script
+  - task: writeFile
+    inputs:
+      - frequency: once
+        destination: C:\ProgramData\ssh\download_ec2_pubkey.ps1
+        content: |-
+          #!powershell
+          # Script downloads the OpenSSH pubkey from AWS EC2 instance metadata and set it
+          $openSSHAuthorizedKeys = 'C:\ProgramData\ssh\administrators_authorized_keys'
+
+          # Download the pubkey from ec2 metadata to key file
+          $keyUrl = "http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key"
+          $keyRespStream = [System.Net.WebRequest]::Create($keyUrl).GetResponse().GetResponseStream()
+          $streamReader = New-Object System.IO.StreamReader $keyRespStream
+          $streamReader.ReadToEnd() | Out-File -FilePath $openSSHAuthorizedKeys -Encoding ASCII
+
+          # Ensure access control on authorized_keys meets the requirements
+          $acl = Get-ACL -Path $openSSHAuthorizedKeys
+          $acl.SetAccessRuleProtection($True, $True)
+          Set-Acl -Path $openSSHAuthorizedKeys -AclObject $acl
+          $acl = Get-ACL -Path $openSSHAuthorizedKeys
+          $ar = New-Object System.Security.AccessControl.FileSystemAccessRule( `
+              "NT Authority\Authenticated Users", "ReadAndExecute", "Allow")
+          $acl.RemoveAccessRule($ar)
+          $ar = New-Object System.Security.AccessControl.FileSystemAccessRule( `
+              "BUILTIN\Administrators", "FullControl", "Allow")
+          $acl.RemoveAccessRule($ar)
+          $ar = New-Object System.Security.AccessControl.FileSystemAccessRule( `
+              "BUILTIN\Users", "FullControl", "Allow")
+          $acl.RemoveAccessRule($ar)
+          Set-Acl -Path $openSSHAuthorizedKeys -AclObject $acl
+
   - task: executeScript
     inputs:
       - frequency: once
@@ -67,6 +99,21 @@ tasks:
               </Select></Query></QueryList>
           "@
 
+          $principal = New-ScheduledTaskPrincipal -UserId System -LogonType S4U
+          $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries 
+
+          Register-ScheduledTask -TaskName $name -Trigger $trigger -Action $action -Description $desc -Principal $principal -Settings $settings
+
+      # Add SSH public key receiver from AWS EC2 MetaData upon instance startup
+      - frequency: once
+        type: powershell
+        runAs: localSystem
+        content: |-
+          $name = "Download AWS EC2 OpenSSH public key"
+          $desc = "Automatically downloads the AWS EC2 instance public key to allow the Administrator access"
+
+          $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoProfile -File C:\ProgramData\ssh\download_ec2_pubkey.ps1'
+          $trigger = New-ScheduledTaskTrigger -AtStartup
           $principal = New-ScheduledTaskPrincipal -UserId System -LogonType S4U
           $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries 
 

--- a/playbooks/base_image.yml
+++ b/playbooks/base_image.yml
@@ -10,4 +10,7 @@
         name: vmtools  # It's critical for appleGPU to install tools in the first OS boot
 
     - include_role:
+        name: openssh_server  # ~2x faster than winrm transport on windows
+
+    - include_role:
         name: cleanup

--- a/playbooks/roles/cleanup/tasks/linux.yml
+++ b/playbooks/roles/cleanup/tasks/linux.yml
@@ -15,11 +15,17 @@
           - /tmp
       register: reg_caches
 
+    - name: Check ssh host keys
+      find:
+        patterns: ssh_host_*
+        paths: /etc/ssh
+      register: reg_ssh_host_keys
+
     - name: Clean found items
       when: reg_caches.matched > 0
       # The /tmp/lin directory could be mounted as RO, so ignoring it in case of error
       ignore_errors: "{{ item.path == '/tmp/lin' }}"
-      with_items: "{{ reg_caches.files }}"
+      with_items: "{{ reg_caches.files + reg_ssh_host_keys.files }}"
       file:
         path: "{{ item.path }}"
         state: absent

--- a/playbooks/roles/cleanup/tasks/macos.yml
+++ b/playbooks/roles/cleanup/tasks/macos.yml
@@ -20,6 +20,7 @@
     path: /Users/{{ ansible_user }}/.Trash
 
 - name: Clean caches & tmp dirs
+  become: true
   block:
     - name: Check caches & temp files
       find:
@@ -30,13 +31,18 @@
           - /tmp
       register: reg_caches
 
+    - name: Check ssh host keys
+      find:
+        patterns: ssh_host_*
+        paths: /etc/ssh
+      register: reg_ssh_host_keys
+
     - name: Clean found items
       when: reg_caches.matched > 0
-      become: true
       # Caches cleaning on MacOS 11.6 is harder with SIP activated so some folders can't be
       # accessible, so ignoring them in case they producing an error
       ignore_errors: true
-      with_items: "{{ reg_caches.files }}"
+      with_items: "{{ reg_caches.files + reg_ssh_host_keys.files }}"
       file:
         path: "{{ item.path }}"
         state: absent

--- a/playbooks/roles/cleanup/tasks/windows.yml
+++ b/playbooks/roles/cleanup/tasks/windows.yml
@@ -14,7 +14,7 @@
   ignore_errors: true  # don't fail in case those services are not here
   win_shell: Stop-Process -Name vmtoolsd -Force
 
-- name: Clean caches & tmp dirs
+- name: Clean caches & tmp dirs and ssh host keys/auth
   win_shell: Remove-Item '{{ item }}' -force -recurse
   with_items:
     - C:\tmp\*
@@ -22,6 +22,8 @@
     - C:\Windows\Prefetch\*
     - C:\Documents and Settings\*\Local Settings\temp\*
     - C:\Users\*\Appdata\Local\Temp\*
+    - C:\ProgramData\ssh\ssh_host*
+    - C:\ProgramData\ssh\*authorized_keys
 
 - name: Clean event log
   win_shell: Get-EventLog -List | ForEach-Object { Clear-EventLog -LogName $_.Log }

--- a/playbooks/roles/git/tasks/windows.yml
+++ b/playbooks/roles/git/tasks/windows.yml
@@ -14,4 +14,4 @@
     elements: C:\util\git\bin
 
 - name: Check git binary was installed properly
-  win_command: git --version
+  win_command: C:\util\git\bin\git --version

--- a/playbooks/roles/macsdklibs/tasks/main.yml
+++ b/playbooks/roles/macsdklibs/tasks/main.yml
@@ -2,7 +2,3 @@
 - name: Execute on Linux
   include_tasks: linux.yml
   when: ansible_system == 'Linux'
-
-- name: Execute on Windows
-  include_tasks: windows.yml
-  when: ansible_system == 'Win32NT'

--- a/playbooks/roles/openssh_server/README.md
+++ b/playbooks/roles/openssh_server/README.md
@@ -1,0 +1,11 @@
+# OpenSSH Server role
+
+The role installs OpenSSH on the remote machine, can listen on multiple ports and replaces winrm if
+uses port 5986.
+
+Primarily created for Windows because all other systems already have it. SSH proven to be much
+faster transport than WinRM and it actually unifies the infrastructure access so quite benificial.
+
+## Tasks
+
+* Install SSHd

--- a/playbooks/roles/openssh_server/defaults/main.yml
+++ b/playbooks/roles/openssh_server/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# This file is from Windows 10 FUD: en_windows_10_features_on_demand_part_1_version_1903_x64_dvd_1076e85a.iso
+openssh_server_win2019_download_url: https://artifact-storage/aquarium/files/win/OpenSSH-Server-Package~31bf3856ad364e35~amd64~~win2019.cab
+openssh_server_win2019_download_checksum: sha256:be99d5641c90dfe4db60b38365e519f35b5315abb2bdb9e0f2e668b444ebaf2e
+# This file is from Windows 2022 FUD: 20348.1.210507-1500.fe_release_amd64fre_SERVER_LOF_PACKAGES_OEM.iso
+openssh_server_win2022_download_url: https://artifact-storage/aquarium/files/win/OpenSSH-Server-Package~31bf3856ad364e35~amd64~~win2022.cab
+openssh_server_win2022_download_checksum: sha256:00db110df420dc4571954703ba8e5a9b00ff86e957026bd62c0a78ca901e769a
+openssh_server_win_download_url: "{{ lookup('vars', 'openssh_server_win'+ansible_os_name.split()[3]+'_download_url', default=openssh_server_win2022_download_url) }}"
+openssh_server_win_download_checksum: sha256:{{ lookup('vars', 'openssh_server_win'+ansible_os_name.split()[3]+'_download_checksum', default=openssh_server_win2022_download_checksum) }}
+
+# Needed for Win Server 2019 to install OpenSSH
+openssh_server_fod_win_download_url: https://artifact-storage/aquarium/files/win/17763.1.180914-1434.rs5_release_amd64fre_SERVER-FOD-PACKAGES_OEM_amd64fre_MULTI.iso
+openssh_server_fod_win_download_checksum: sha256:691a57879da249170400574a4919150c9b11f64f97f92f405dd36dcefcf33701
+
+# Defines port to use by OpenSSH. If set to 5986 - will replace WinRM service
+openssh_server_ports:
+  - 22

--- a/playbooks/roles/openssh_server/tasks/main.yml
+++ b/playbooks/roles/openssh_server/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Execute on Windows
+  include_tasks: windows.yml
+  when: ansible_system == 'Win32NT'

--- a/playbooks/roles/openssh_server/tasks/windows.yml
+++ b/playbooks/roles/openssh_server/tasks/windows.yml
@@ -1,0 +1,59 @@
+---
+# Windows Server 2019 needs FOD dir & metadata to properly install openssh
+- when: '"Windows Server 2019" in ansible_os_name'
+  include_tasks: windows_fod.yml
+
+- name: Download OpenSSH-Server cab archive to the environment
+  include_role:
+    name: download
+  vars:
+    download_url: '{{ openssh_server_win2022_download_url }}'
+    download_checksum: '{{ openssh_server_win2022_download_checksum }}'
+
+- name: Create fod directory
+  win_file:
+    path: C:\tmp\fod
+    state: directory
+
+- name: Copy the OpenSSH server archive to fod directory
+  win_copy:
+    src: "{{ download_path }}"
+    dest: C:\tmp\fod\OpenSSH-Server-Package~31bf3856ad364e35~amd64~~.cab
+    remote_src: true
+
+- name: Install OpenSSH with feature installer
+  win_shell: Add-WindowsCapability -Online -LimitAccess -Name "OpenSSH.Server~~~~0.0.1.0" -Source C:\tmp\fod
+
+- name: Create the firewall rule to allow OpenSSH ports
+  win_shell: >
+    New-NetFirewallRule -Name "OpenSSH" -DisplayName "OpenSSH" -Description "Allow SSH ports"
+    -Profile Any -Direction Inbound -Action Allow -Protocol TCP -Program Any -LocalAddress Any
+    -RemoteAddress Any -LocalPort {{ openssh_server_ports | join(',') }} -RemotePort Any
+
+- name: Run OpenSSH first time to generate the default configs
+  win_service:
+    name: sshd
+    start_mode: auto
+    state: started
+
+- name: Set the default OpenSSH shell to PowerShell
+  win_regedit:
+    path: HKLM:\SOFTWARE\OpenSSH
+    name: DefaultShell
+    data: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    type: string
+    state: present
+
+- name: Set OpenSSH ports to listen
+  win_lineinfile:
+    path: C:\ProgramData\ssh\sshd_config
+    regex: '^Port {{ item }}'
+    insertafter: '^#Port '
+    line: 'Port {{ item }}'
+  loop: '{{ openssh_server_ports }}'
+
+- name: Do not run WinRM on next boot if it's port is used by OpenSSH
+  when: 5986 in openssh_server_ports
+  win_service:
+    name: WinRM
+    start_mode: manual

--- a/playbooks/roles/openssh_server/tasks/windows_fod.yml
+++ b/playbooks/roles/openssh_server/tasks/windows_fod.yml
@@ -1,0 +1,18 @@
+---
+# Installs Features on Demand needed by Windows 2019 to install OpenSSH
+
+- name: Download FOD iso to the environment
+  include_role:
+    name: download
+  vars:
+    download_url: '{{ openssh_server_fod_win_download_url }}'
+    download_checksum: '{{ openssh_server_fod_win_download_checksum }}'
+
+- name: Mount the FOD iso as a disk
+  win_shell: Mount-DiskImage -ImagePath "{{ download_path }}"
+
+- name: Copy FOD files to fod directory
+  win_shell: 'Copy-Item D: C:\tmp\fod -Recurse'
+
+- name: Umount the FOD iso disk
+  win_shell: Dismount-DiskImage -ImagePath "{{ download_path }}"

--- a/specs/aws/winserver2019.yml
+++ b/specs/aws/winserver2019.yml
@@ -59,3 +59,5 @@ provisioners:
       - ansible_password={{ build `Password` }}
       - -e
       - ansible_winrm_server_cert_validation=ignore
+      - -e
+      - '{"openssh_server_ports":[22,80]}'  # Use 80 port as backup for SSH in case 22 is blocked

--- a/specs/aws/winserver2019/ci.yml
+++ b/specs/aws/winserver2019/ci.yml
@@ -44,24 +44,19 @@ builders:
       filters:
         tag:Class: image-build-winrm
 
-    communicator: winrm
-    winrm_username: Administrator
-    winrm_use_ssl: true
-    winrm_insecure: true
+    # In the base image we're using OpenSSH for Windows
+    ssh_username: Administrator
+    ssh_port: 80
 
 provisioners:
   - type: ansible
     command: ./scripts/run_ansible.sh
-    user: Administrator
     playbook_file: playbooks/ci_image.yml
-    use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
       - -e
-      - ansible_password={{ build `Password` }}
-      - -e
-      - ansible_winrm_server_cert_validation=ignore
+      - ansible_shell_type=powershell
       - -e
       - jre_extract_path=C:\util\jre8
       - -e

--- a/specs/aws/winserver2019/vs2019.yml
+++ b/specs/aws/winserver2019/vs2019.yml
@@ -44,23 +44,18 @@ builders:
       filters:
         tag:Class: image-build-winrm
 
-    communicator: winrm
-    winrm_username: Administrator
-    winrm_use_ssl: true
-    winrm_insecure: true
+    # In the base image we're using OpenSSH for Windows
+    ssh_username: Administrator
+    ssh_port: 80
 
 provisioners:
   - type: ansible
     command: ./scripts/run_ansible.sh
-    user: Administrator
     playbook_file: playbooks/visualstudio_image.yml
-    use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
       - -e
-      - ansible_password={{ build `Password` }}
-      - -e
-      - ansible_winrm_server_cert_validation=ignore
+      - ansible_shell_type=powershell
       - -e
       - 'visualstudio_install_path="C:\Program Files (x86)\MSVS"'

--- a/specs/aws/winserver2019/vs2019/ci.yml
+++ b/specs/aws/winserver2019/vs2019/ci.yml
@@ -44,24 +44,19 @@ builders:
       filters:
         tag:Class: image-build-winrm
 
-    communicator: winrm
-    winrm_username: Administrator
-    winrm_use_ssl: true
-    winrm_insecure: true
+    # In the base image we're using OpenSSH for Windows
+    ssh_username: Administrator
+    ssh_port: 80
 
 provisioners:
   - type: ansible
     command: ./scripts/run_ansible.sh
-    user: Administrator
     playbook_file: playbooks/ci_image.yml
-    use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
       - -e
-      - ansible_password={{ build `Password` }}
-      - -e
-      - ansible_winrm_server_cert_validation=ignore
+      - ansible_shell_type=powershell
       - -e
       - jre_extract_path=C:\util\jre8
       - -e

--- a/specs/aws/winserver2022.yml
+++ b/specs/aws/winserver2022.yml
@@ -59,3 +59,5 @@ provisioners:
       - ansible_password={{ build `Password` }}
       - -e
       - ansible_winrm_server_cert_validation=ignore
+      - -e
+      - '{"openssh_server_ports":[22,80]}'  # Use 80 port as backup for SSH in case 22 is blocked

--- a/specs/aws/winserver2022/ci.yml
+++ b/specs/aws/winserver2022/ci.yml
@@ -44,24 +44,19 @@ builders:
       filters:
         tag:Class: image-build-winrm
 
-    communicator: winrm
-    winrm_username: Administrator
-    winrm_use_ssl: true
-    winrm_insecure: true
+    # In the base image we're using OpenSSH for Windows
+    ssh_username: Administrator
+    ssh_port: 80
 
 provisioners:
   - type: ansible
     command: ./scripts/run_ansible.sh
-    user: Administrator
     playbook_file: playbooks/ci_image.yml
-    use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
       - -e
-      - ansible_password={{ build `Password` }}
-      - -e
-      - ansible_winrm_server_cert_validation=ignore
+      - ansible_shell_type=powershell
       - -e
       - jre_extract_path=C:\util\jre8
       - -e

--- a/specs/aws/winserver2022/vs2022.yml
+++ b/specs/aws/winserver2022/vs2022.yml
@@ -44,24 +44,19 @@ builders:
       filters:
         tag:Class: image-build-winrm
 
-    communicator: winrm
-    winrm_username: Administrator
-    winrm_use_ssl: true
-    winrm_insecure: true
+    # In the base image we're using OpenSSH for Windows
+    ssh_username: Administrator
+    ssh_port: 80
 
 provisioners:
   - type: ansible
     command: ./scripts/run_ansible.sh
-    user: Administrator
     playbook_file: playbooks/visualstudio_image.yml
-    use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
       - -e
-      - ansible_password={{ build `Password` }}
-      - -e
-      - ansible_winrm_server_cert_validation=ignore
+      - ansible_shell_type=powershell
       - -e
       - visualstudio_download_url={% print visualstudio_version_1705_download_url %}
       - -e

--- a/specs/aws/winserver2022/vs2022/ci.yml
+++ b/specs/aws/winserver2022/vs2022/ci.yml
@@ -44,24 +44,19 @@ builders:
       filters:
         tag:Class: image-build-winrm
 
-    communicator: winrm
-    winrm_username: Administrator
-    winrm_use_ssl: true
-    winrm_insecure: true
+    # In the base image we're using OpenSSH for Windows
+    ssh_username: Administrator
+    ssh_port: 80
 
 provisioners:
   - type: ansible
     command: ./scripts/run_ansible.sh
-    user: Administrator
     playbook_file: playbooks/ci_image.yml
-    use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
       - -e
-      - ansible_password={{ build `Password` }}
-      - -e
-      - ansible_winrm_server_cert_validation=ignore
+      - ansible_shell_type=powershell
       - -e
       - jre_extract_path=C:\util\jre8
       - -e


### PR DESCRIPTION
The change adds OpenSSH with necessary AWS EC2 scripts to automatically receive pubkey for Administrator on boot.

## Description

Adding OpenSSH to Windows actually allows us to unify the shell access to machines and helps with transferring files to the remote instance (due to winrm issue with binary data transfers). Unfortunately packer don't want to decrypt password if we're not using winrm so I also added scripts which helps to create administrator authorized_keys file with instance pubkey in it.

## Related Issue

resolves: #3 

## Motivation and Context

Not strictly needed - but a great addition I think.

## How Has This Been Tested?

Manually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

