### PR TITLE
Allowed to use repository scripts from overlay one & some bug fixes

### DIFF
--- a/.gitignore_prop
+++ b/.gitignore_prop
@@ -1,10 +1,8 @@
-# Default aquarium bait ignore file
+# Ignore file for org repositories
 /.venv
 /out
 /records
 /packer_cache
-
-/override.yml
 
 /specs/*.json
 /specs/**/*.json

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ You can grep all the variables that have `_url: http` and put them in the file a
 one-by-one. Some specs are overriding the main download variable by the template (as in example for
 xcode) and you can specify the version for each one to build the different images properly.
 
-**WARNING**: Make sure you using http as your artifact transport, otherwise it could interfere with
-the local proxy and won't allow you to download the artifacts from the role.
+**WARNING**: Make sure you using https as your artifact transport, otherwise it could interfere
+with the local proxy and won't allow you to download the artifacts from the role.
+
+For the other overrides look 
 
 ### 3. Run build
 
@@ -344,6 +346,54 @@ running the VM as nogui - and you always have a way to run the VMWare UI interfa
 ```
 $ vmrun start worker/worker.vmx nogui
 ```
+
+## Overlay repository
+
+For sure your organization don't want to share the specific overrides, specs, playbooks and roles.
+You can actually make this happen by creating the new repository with the next layout:
+
+* bait/
+   > git submodule with aquarium-bait repo content, you still be able to use `bait/specs` to build images
+* out/
+   > dir where the images will be stored. Better to symlink to `bait/out`
+
+* specs/
+   > specs of your images - they are able to use `bait/specs` images as child/parents
+* playbooks/
+   > your playbooks, roles & files cache
+   * files
+      > symlink to `../bait/playbooks/files`
+
+* .ansible-lint
+   > Symlink to `bait/.ansible-lint`
+* .gitignore
+   > symlink to `bait/.gitignore_prop`
+* .yamllint.yml
+   > Symlink to `bait/.yamllint.yml`
+* ansible.cfg
+   > a bit of overrides to make ansible work well
+   ```ini
+   [defaults]
+   # To use roles from the Bait
+   roles_path=./playbooks/roles:./bait/playbooks/roles
+   ```
+* override.yml
+   > your overrides for url's and other ansible variables. Check **Ansible files** for details
+
+* build_image.sh
+   > shell script to run `bait/build_image.sh`, symlink will not work here
+   ```sh
+   #!/bin/sh -e
+   ./bait/build_image.sh "$@"
+   ```
+* check_style.sh
+   > symlink to `bait/check_style.sh`
+* pack_image.sh
+   > symlink to `bait/pack_image.sh`
+* upload_image.sh
+   > symlink to `bait/upload_image.sh`
+* upload_iso.sh
+   > symlink to `bait/upload_iso.sh`
 
 ## Advices on testing
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -11,27 +11,87 @@
 
 # Build packer images
 # Usage:
-#   ./build_image.sh <specs/path/to.yml> [...]
+#   ./build_image.sh <specs/path/to.yml>
 #
 # Debug mode:
-#   DEBUG=true ./build_image.sh ...
+#   DEBUG=true ./build_image.sh <specs/path/to.yml>
 
-cd "$(dirname "$0")"
 root_dir="$PWD"
+cd $(dirname "$0")
+script_dir="$PWD"
+cd "${root_dir}"
+
+# Used to separate different builds on the same machine
+export BAIT_SESSION=$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
 
 # Disable packer auto-update calls
 export CHECKPOINT_DISABLE=1
 # No need to color the output to store proper log files
 export PACKER_NO_COLOR=1
 # Set root dir to use in packer configs
-export PACKER_ROOT="${root_dir}"
+export PACKER_ROOT="${script_dir}"
+# Increase the max attempts to 1h30m for AWS wait of AMI. Could take a while (up to 1h) for big
+# images and raise "Error waiting for AMI: Failed with ResourceNotReady error" on image completion
+export AWS_MAX_ATTEMPTS=360
+
+yml="$1"
+# We need to get the path starts with `specs/` to process it properly
+# due to an ability to run from outside overlay repository
+yml_bait="$yml"
+if [ "$(echo "$yml_bait" | cut -d/ -f 1)" != 'specs' ]; then
+    yml_bait=$(echo "$yml_bait" | cut -d/ -f 2-) ;
+fi
+if [ "$(echo "$yml_bait" | cut -d/ -f 1)" != 'specs' ]; then
+    echo "ERROR: Incorrect spec path is provided: $yml"
+    exit 1
+fi
+
+##
+# Collecting info and verifying basic checks
+##
+stage=$(( $(echo "$yml_bait" | tr / '\n' | wc -l)-2 ))
+
+image_type=$(echo "$yml_bait" | cut -d/ -f2)
+image_outdir="${root_dir}/out/${image_type}"
+mkdir -p "${image_outdir}"
+image=$(echo "${yml_bait}" | cut -d. -f1 | cut -d/ -f3- | tr / -)
+echo "INFO: Building image for ${image_type} '${image}' ${BAIT_SESSION}..."
+
+if [ "$image_type" = 'vmx' ]; then
+    # Make sure no VM is running currently to provide the clean environment for the build
+    if which vmrun > /dev/null 2>&1; then
+        if [ "x$(vmrun list | head -1 | rev | cut -d" " -f 1)" != "x0" ]; then
+            echo "ERROR: Found running VMware VM's, please shutdown them before running the build:\n$(vmrun list)"
+            exit 1
+        fi
+    fi
+
+    # Check the spec have headless mode enabled in release mode
+    if [ "x${DEBUG}" = 'x' ]; then
+        if [ "x$(grep -s 'headless:' "${yml}" | tr -d ' ')" != 'xheadless:true' ]; then
+            echo "ERROR: The spec doesn't contain the headless mode enabled: ${yml}"
+            exit 1
+        fi
+    fi
+
+    # Check the minimum disk space (200GB) is available for proper VM disk cleanup
+    if [ "$(df -m "${image_outdir}" | tail -1 | awk '{print $4}')" -lt 201000 ]; then
+        echo "ERROR: Available disk space is lower than required 200GB for VM"
+        exit 1
+    fi
+fi
+
+if [ "$(find "${image_outdir}" -maxdepth 1 -type d -name "${image}-[0-9]*")" ]; then
+    echo "INFO:  skip: the output path '${image_outdir}/${image}-[0-9]*' already exists"
+    exit 1
+fi
 
 ##
 # Running the local proxy process to workaround the VPN tunnel routing
 ##
 # Get the available port to listen on localhost
 proxy_port=$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')
-./scripts/run_proxy_local.sh $proxy_port &
+"${script_dir}/scripts/run_proxy_local.sh" $proxy_port &
 # Exporting proxy for the Ansible WinRM transport
 # TODO: it's not perfect if you want to use http transport to get
 # your artifacts but it's a simpliest solution I found for now
@@ -40,173 +100,94 @@ export http_proxy="socks5://127.0.0.1:$proxy_port"
 # Clean of the running background apps on exit
 clean_bg() {
     find "${root_dir}/specs" -name '*.json' -delete
-    pkill -SIGINT -f './scripts/vncrecord.py' || true
-    pkill -SIGTERM -f 'tail -f /tmp/packer.log' || true
+    pkill -SIGINT -f "scripts/vncrecord.py /tmp/bait-packer-${BAIT_SESSION}.log" || true
+    if [ ! -f "./records/${image}.mp4" ]; then
+        pkill -f "scripts/vncrecord.py /tmp/bait-packer-${BAIT_SESSION}.log" || true
+    fi
+    pkill -SIGTERM -f "tail -f /tmp/bait-packer-${BAIT_SESSION}.log" || true
     # TODO: Remove the docker images
 }
 
-trap "clean_bg ; pkill -f './scripts/proxy_local.py' || true" EXIT
-
-# This is needed to properly work with the spaces in the path
-spec_list=''
-_IFS="$IFS"
-IFS='|'
-for item in "$@"; do
-    spec_list="$spec_list$item|"
-done
+trap "clean_bg ; pkill -f 'scripts/proxy_local.py $proxy_port' || true" EXIT
 
 ##
-# The process walks on the different levels of packer dir tree and process the configs
+# Collecting packer params to build the image
 ##
-stage=1
-while true; do
-    if [ "x$1" != "x" ]; then
-        # Need to make sure we will build the provided specs by stage
-        to_process=''
-        for yml in $spec_list; do
-            if [ $(echo "$yml" | tr / '\n' | wc -l) -eq $(($stage+2)) ]; then
-                to_process="$to_process$yml|"
-            else
-                spec_list_tmp="$spec_list_tmp$yml|"
-            fi
+packer_params="-var aquarium_bait_proxy_port=${proxy_port}"
+packer_params="$packer_params -var bait_path=${script_dir}"
+packer_params="$packer_params -var image_name=${image}"
+packer_params="$packer_params -var username=packer -var password=packer"
+packer_params="$packer_params -var out_full_path=${image_outdir}"
+if [ $stage -gt 1 ]; then
+    parent_name=$(echo "${yml_bait}" | cut -d. -f1 | cut -d/ -f3- | rev | cut -d/ -f2- | rev | tr / -)
+    if [ $image_type != "aws" ]; then
+        # Filter the dirs in addition with grep due to the childrens could be found too
+        parent_image=$(find "${image_outdir}" -type d -name "${parent_name}-*" | grep -E "${parent_name}-[^-]*$" || printf '')
+        parent_version=$(basename "${parent_image}" | rev | cut -d- -f1 | rev)
+        if [ $(echo "$parent_image" | wc -l) -gt 1 ]; then
+            echo "ERROR:  there is more than one parent image '${parent_name}'."
+            echo "        Please move the unnecessary one aside of out directory:\n$parent_image"
+            exit 1
+        elif [ "x$parent_image" = 'x' ]; then
+            echo "ERROR:  there is no required parent image with name '${parent_name}'."
+            echo "        Please download the prebuilt one (preferrable) or build it yourself."
+            exit 1
+        fi
+        echo "INFO:  using parent image: ${parent_image}"
+        packer_params="$packer_params -var parent_full_path=${parent_image}"
+        packer_params="$packer_params -var parent_version=${parent_version}"
+    fi
+    packer_params="$packer_params -var parent_name=${parent_name}"
+
+    if [ "$image_type" = 'docker' ]; then
+        echo "INFO: Loading Docker parent images"
+        parent_manifest="${parent_image}/${parent_name}-${parent_version}.yml"
+        if [ ! -f "${parent_manifest}" ]; then
+            echo "ERROR: Unable to find parent image manifest: ${parent_manifest}"
+            exit 1
+        fi
+        # Getting the list of the other dependencies and load them in reverse order
+        image_deps=$(grep -A100 -m 1 '^parents:' "${parent_manifest}" | tail -n +2 | awk '{if(/^ /)print;else exit}' | cut -d- -f2- | tac)
+        for dep_name in ${image_deps}; do
+            dep_image="$(dirname "${parent_image}")/${dep_name}"
+            dep_tar="${dep_image}/$(echo "${dep_name}" | rev | cut -d- -f2- | rev).tar"
+            echo "INFO:   loading ${dep_tar}..."
+            docker image load -i "${dep_tar}"
         done
-        spec_list="$spec_list_tmp"
-        spec_list_tmp=''
+
+        # When all the deps images are loaded - load the closest parent image
+        echo "INFO:   loading ${parent_image}/${parent_name}.tar..."
+        docker image load -i "${parent_image}/${parent_name}.tar"
     fi
-    if [ "${spec_list}" -a ! "${to_process}" ]; then
-        echo "Skipping Stage ${stage}"
-        stage=$(($stage+1))
-        continue
-    fi
-    [ "${to_process}" ] || break
+fi
 
-    echo "INFO: ---------------"
-    echo "INFO: Stage: ${stage}"
-    echo "INFO: ---------------"
+clean_bg
 
-    # We building single-threaded because build of the images in parallel
-    # will lead to resource conflicts and the timeouts (for VNC scripts)
-    # will not be met.
-    for yml in $to_process; do
-        IFS="$_IFS"
+echo "INFO:  generating packer json for '${yml}'..."
+cat "${yml}" | "${script_dir}/scripts/run_yaml2json.sh" > "${yml}.json"
 
-        image_type=$(echo "$yml" | cut -d/ -f2)
-        image_outdir="${root_dir}/out/${image_type}"
-        mkdir -p "${image_outdir}"
-        image=$(echo "${yml}" | cut -d. -f1 | cut -d/ -f3- | tr / -)
-        echo "INFO: Building image for ${image_type} '${image}'..."
+if [ "$image_type" = 'vmx' ]; then
+    # Cleaning the non-tracked files from the init directory
+    git -C "${root_dir}" clean -fX init/vmx/ || true
 
-        if [ "$image_type" = 'vmx' ]; then
-            # Make sure no VM is running currently to provide the clean environment for the build
-            if which vmrun > /dev/null 2>&1; then
-                if [ "x$(vmrun list | head -1 | rev | cut -d" " -f 1)" != "x0" ]; then
-                    echo "ERROR: Found running VMware VM's, please shutdown them before running the build:\n$(vmrun list)"
-                    exit 1
-                fi
-            fi
+    # Running the vncrecord script to capture VNC screen during the build
+    rm -rf "./records/${image}.mp4"
+    mkdir -p ./records
+    rm -f /tmp/bait-packer-${BAIT_SESSION}.log
+    "${script_dir}/scripts/run_vncrecord.sh" /tmp/bait-packer-${BAIT_SESSION}.log "./records/${image}.mp4" &
+fi
 
-            # Check the spec have headless mode enabled in release mode
-            if [ "x${DEBUG}" = 'x' ]; then
-                if [ "x$(grep -s 'headless:' "${yml}" | tr -d ' ')" != 'xheadless:true' ]; then
-                    echo "ERROR: The spec doesn't contain the headless mode enabled: ${yml}"
-                    exit 1
-                fi
-            fi
+echo "INFO:  running packer build ${BAIT_SESSION}"
+if [ "x${DEBUG}" = 'x' ]; then
+    PACKER_LOG=1 PACKER_LOG_PATH=/tmp/bait-packer-${BAIT_SESSION}.log packer build $packer_params "${yml}.json"
+    "${script_dir}/scripts/run_postprocess_${image_type}.sh" "${BAIT_SESSION}" "${image_outdir}/${image}"
+else
+    echo "WARNING:  running DEBUG image build - you will not be able to upload it"
+    touch /tmp/bait-packer-${BAIT_SESSION}.log
+    tail -f /tmp/bait-packer-${BAIT_SESSION}.log &
+    PACKER_LOG=1 packer build -on-error=ask $packer_params "${yml}.json" > /tmp/bait-packer-${BAIT_SESSION}.log 2>&1
+fi
 
-            # Check the minimum disk space (200GB) is available for proper VM disk cleanup
-            if [ "$(df -m "${image_outdir}" | tail -1 | awk '{print $4}')" -lt 201000 ]; then
-                echo "ERROR: Available disk space is lower than required 200GB for VM"
-                exit 1
-            fi
-        fi
+clean_bg
 
-        if [ "$(find "${image_outdir}" -maxdepth 1 -type d -name "${image}-[0-9]*")" ]; then
-            echo "INFO:  skip: the output path '${image_outdir}/${image}-[0-9]*' already exists"
-            continue
-        fi
-
-        # Collecting packer params to build the image
-        packer_params="-var aquarium_bait_proxy_port=${proxy_port}"
-        packer_params="$packer_params -var username=packer -var password=packer"
-        packer_params="$packer_params -var image_name=${image}"
-        packer_params="$packer_params -var out_full_path=${image_outdir}"
-        if [ $stage -gt 1 ]; then
-            parent_name=$(echo "${yml}" | cut -d. -f1 | cut -d/ -f3- | rev | cut -d/ -f2- | rev | tr / -)
-            if [ $image_type != "aws" ]; then
-                # Filter the dirs in addition with grep due to the childrens could be found too
-                parent_image=$(find "${image_outdir}" -type d -name "${parent_name}-*" | grep -E "${parent_name}-[^-]*$" || printf '')
-                parent_version=$(basename "${parent_image}" | rev | cut -d- -f1 | rev)
-                if [ $(echo "$parent_image" | wc -l) -gt 1 ]; then
-                    echo "ERROR:  there is more than one parent image '${parent_name}'."
-                    echo "        Please move the unnecessary one aside of out directory:\n$parent_image"
-                    continue
-                elif [ "x$parent_image" = 'x' ]; then
-                    echo "ERROR:  there is no required parent image with name '${parent_name}'."
-                    echo "        Please download the prebuilt one (preferrable) or build it yourself."
-                    continue
-                fi
-                echo "INFO:  using parent image: ${parent_image}"
-                packer_params="$packer_params -var parent_full_path=${parent_image}"
-                packer_params="$packer_params -var parent_version=${parent_version}"
-            fi
-            packer_params="$packer_params -var parent_name=${parent_name}"
-
-            if [ "$image_type" = 'docker' ]; then
-                echo "INFO: Loading Docker parent images"
-                parent_manifest="${parent_image}/${parent_name}-${parent_version}.yml"
-                if [ ! -f "${parent_manifest}" ]; then
-                    echo "ERROR: Unable to find parent image manifest: ${parent_manifest}"
-                    exit 1
-                fi
-                # Getting the list of the other dependencies and load them in reverse order
-                image_deps=$(grep -A100 -m 1 '^parents:' "${parent_manifest}" | tail -n +2 | awk '{if(/^ /)print;else exit}' | cut -d- -f2- | tac)
-                for dep_name in ${image_deps}; do
-                    dep_image="$(dirname "${parent_image}")/${dep_name}"
-                    dep_tar="${dep_image}/$(echo "${dep_name}" | rev | cut -d- -f2- | rev).tar"
-                    echo "INFO:   loading ${dep_tar}..."
-                    docker image load -i "${dep_tar}"
-                done
-
-                # When all the deps images are loaded - load the closest parent image
-                echo "INFO:   loading ${parent_image}/${parent_name}.tar..."
-                docker image load -i "${parent_image}/${parent_name}.tar"
-            fi
-        fi
-
-        clean_bg
-
-        echo "INFO:  generating packer json for '${yml}'..."
-        cat "${yml}" | ./scripts/run_yaml2json.sh > "${yml}.json"
-
-        if [ "$image_type" = 'vmx' ]; then
-            # Cleaning the non-tracked files from the init directory
-            git clean -fX ./init/vmx/ || true
-
-            # Running the vncrecord script to capture VNC screen during the build
-            rm -rf "./records/${image}.mp4"
-            mkdir -p ./records
-            rm -f /tmp/packer.log
-            ./scripts/run_vncrecord.sh /tmp/packer.log "./records/${image}.mp4" &
-        fi
-
-        echo 'INFO:  running packer build'
-        if [ "x${DEBUG}" = 'x' ]; then
-            PACKER_LOG=1 PACKER_LOG_PATH=/tmp/packer.log packer build $packer_params "${yml}.json"
-            # /tmp/packer.log is copied in the post processing script to the image dir
-            "./scripts/run_postprocess_${image_type}.sh" "${image_outdir}/${image}"
-        else
-            echo "WARNING:  running DEBUG image build - you will not be able to upload it"
-            touch /tmp/packer.log
-            tail -f /tmp/packer.log &
-            PACKER_LOG=1 packer build -on-error=ask $packer_params "${yml}.json" > /tmp/packer.log 2>&1
-        fi
-
-        clean_bg
-
-        IFS="|"
-    done
-    stage=$(($stage+1))
-done
-IFS="$_IFS"
-
-echo "INFO: Build completed"
+echo "INFO: Build ${BAIT_SESSION} completed"

--- a/pack_image.sh
+++ b/pack_image.sh
@@ -11,93 +11,90 @@
 
 # Pack the images in out directory
 # Usage:
-#   ./pack_image.sh <out/type/image_dir> [...]
+#   ./pack_image.sh <out/type/image_dir>
 
 curr_dir="$PWD"
 
-for path in "$@"; do
-    cd "${curr_dir}"
+path="$1"
+# Skipping non-dir target
+if [ ! -d "${path}" ]; then
+    echo "ERROR: Unable to find image directory ${path}"
+    exit 1
+fi
 
-    # Skipping non-dir target
-    if [ ! -d "${path}" ]; then
-        echo "ERROR: Unable to find image directory ${path}"
+cd "$(dirname "${path}")"
+
+image=$(basename "${path}")
+type="$(basename "$(dirname "${path}")")"
+# Strip version to get name of the image
+name=$(echo "$image" | rev | cut -d- -f2- | rev)
+
+if [ "x${type}" = 'xvmx' ]; then
+    # Check the lock files are not present
+    if [ "$(find "${image}" -name '*.lck')" ]; then
+        echo "ERROR: Image '${path}' contains lock files, please stop the vmware vms and the application."
         exit 1
     fi
+fi
 
-    cd "$(dirname "${path}")"
+# Make sure the image was build in release mode
+if [ ! -f "${image}/packer.log" ]; then
+    echo "ERROR: Image '${path}' was build in DEBUG mode, only the release images can be packed."
+    exit 1
+fi
 
-    image=$(basename "${path}")
-    type="$(basename "$(dirname "${path}")")"
-    # Strip version to get name of the image
-    name=$(echo "$image" | rev | cut -d- -f2- | rev)
-
-    if [ "x${type}" = 'xvmx' ]; then
-        # Check the lock files are not present
-        if [ "$(find "${image}" -name '*.lck')" ]; then
-            echo "ERROR: Image '${path}' contains lock files, please stop the vmware vms and the application."
-            exit 1
-        fi
+# Check that only allowed files are in the image and make the list of them to pack properly
+need_files=''
+find_noneed_pattern=''
+to_pack_list=''
+# The files will be packed in this order - manifest files first to stream-process them first
+[ "x${type}" != 'xdocker' ] || add_files="$name.tar"
+[ "x${type}" != 'xvmx' ] || add_files="$name.vmx $name.vmsd $name.nvram $name-Snapshot*.vmsn $name.vmxf MainDisk-*.vmdk"
+for filename in "$image.yml" "$image.sha256" 'packer.log' ${add_files}; do
+    found_files=$(sh -c "find '${image}' -name '$filename'" | sort)
+    to_pack_list="$to_pack_list $(echo "$found_files" | tr '\n' ' ')"
+    if [ "x${found_files}" = 'x' ]; then
+        need_files="$need_files $filename"
     fi
-
-    # Make sure the image was build in release mode
-    if [ ! -f "${image}/packer.log" ]; then
-        echo "ERROR: Image '${path}' was build in DEBUG mode, only the release images can be packed."
-        exit 1
-    fi
-
-    # Check that only allowed files are in the image and make the list of them to pack properly
-    need_files=''
-    find_noneed_pattern=''
-    to_pack_list=''
-    # The files will be packed in this order - manifest files first to stream-process them first
-    [ "x${type}" != 'xdocker' ] || add_files="$name.tar"
-    [ "x${type}" != 'xvmx' ] || add_files="$name.vmx $name.vmsd $name.nvram $name-Snapshot*.vmsn $name.vmxf MainDisk-*.vmdk"
-    for filename in "$image.yml" "$image.sha256" 'packer.log' ${add_files}; do
-        found_files=$(sh -c "find '${image}' -name '$filename'" | sort)
-        to_pack_list="$to_pack_list $(echo "$found_files" | tr '\n' ' ')"
-        if [ "x${found_files}" = 'x' ]; then
-            need_files="$need_files $filename"
-        fi
-        find_noneed_pattern="$find_noneed_pattern ! -name '$filename'"
-    done
-    if [ "x$need_files" != 'x' ]; then
-        echo "ERROR: Image '${path}' doesn't contain the required files for packing:\n$need_files"
-        exit 1
-    fi
-    noneed_files=$(sh -c "find '${image}' $find_noneed_pattern")
-    if [ "x$noneed_files" != "x${image}" ]; then
-        echo "ERROR: Image '${path}' contains weird files need to be cleaned before packing: $noneed_files"
-        exit 1
-    fi
-
-    package="$image.tar.xz"
-
-    echo
-    echo "INFO: Processing '${package}'..."
-
-    if [ -f "${package}" ]; then
-        echo "INFO:   skip since '${path}' is already packed"
-        continue
-    fi
-
-    if [ "x${type}" = 'xvmx' ]; then
-        vmsd_file="${image}/${name}.vmsd"
-        if [ -f "${vmsd_file}" ]; then
-            # Cleaning the snapshot clones which is created by the child linked VMs
-            mv "${vmsd_file}" "${vmsd_file}.bak"
-            grep -F -v -e 'snapshot0.clone' -e 'snapshot0.numClones' "${vmsd_file}.bak" > "${vmsd_file}"
-            rm -f "${vmsd_file}.bak"
-        fi
-    fi
-
-    # Print out the image size
-    echo "  Unpacked image size: $(du -d 1 -h "${image}" | tail -1 | cut -f 1)"
-
-    # Pack the image hard, using quarter of the available vcores to not overload the system
-    XZ_OPT="-e9 --threads=$(($(getconf _NPROCESSORS_ONLN)/4))" tar -cvJf "${package}" $to_pack_list
-
-    # Print out the image size
-    echo "  Packed image size: $(du -h "${package}" | cut -f 1)"
+    find_noneed_pattern="$find_noneed_pattern ! -name '$filename'"
 done
+if [ "x$need_files" != 'x' ]; then
+    echo "ERROR: Image '${path}' doesn't contain the required files for packing:\n$need_files"
+    exit 1
+fi
+noneed_files=$(sh -c "find '${image}' $find_noneed_pattern")
+if [ "x$noneed_files" != "x${image}" ]; then
+    echo "ERROR: Image '${path}' contains weird files need to be cleaned before packing: $noneed_files"
+    exit 1
+fi
+
+package="$image.tar.xz"
+
+echo
+echo "INFO: Processing '${package}'..."
+
+if [ -f "${package}" ]; then
+    echo "INFO:   skip since '${path}' is already packed"
+    continue
+fi
+
+if [ "x${type}" = 'xvmx' ]; then
+    vmsd_file="${image}/${name}.vmsd"
+    if [ -f "${vmsd_file}" ]; then
+        # Cleaning the snapshot clones which is created by the child linked VMs
+        mv "${vmsd_file}" "${vmsd_file}.bak"
+        grep -F -v -e 'snapshot0.clone' -e 'snapshot0.numClones' "${vmsd_file}.bak" > "${vmsd_file}"
+        rm -f "${vmsd_file}.bak"
+    fi
+fi
+
+# Print out the image size
+echo "  Unpacked image size: $(du -d 1 -h "${image}" | tail -1 | cut -f 1)"
+
+# Pack the image hard, using quarter of the available vcores to not overload the system
+XZ_OPT="-e9 --threads=$(($(getconf _NPROCESSORS_ONLN)/4))" tar -cvJf "${package}" $to_pack_list
+
+# Print out the image size
+echo "  Packed image size: $(du -h "${package}" | cut -f 1)"
 
 echo "INFO: Pack operation done"

--- a/playbooks/roles/openssh_server/tasks/windows_fod.yml
+++ b/playbooks/roles/openssh_server/tasks/windows_fod.yml
@@ -9,7 +9,7 @@
     download_checksum: '{{ openssh_server_fod_win_download_checksum }}'
 
 - name: Mount the FOD iso as a disk
-  win_shell: win_shell: (Mount-DiskImage -ImagePath "{{ download_path }}" | Get-Volume).DriveLetter
+  win_shell: (Mount-DiskImage -ImagePath "{{ download_path }}" | Get-Volume).DriveLetter
   register: reg_fod_drive_letter
 
 - name: Copy FOD files to fod directory

--- a/playbooks/roles/visualstudio/files/vs_license_watcher.ps1
+++ b/playbooks/roles/visualstudio/files/vs_license_watcher.ps1
@@ -1,0 +1,43 @@
+#!powershell
+# Script waits for file C:\interface\vs_license.txt in format:
+# "<product_key> <product_code>", then reads it, executes StorePID.exe
+# as priviledged user and removes file after that if it was applied.
+
+$license_path = "C:\interface\vs_license.txt"
+$logfile = "C:\tmp\vs_license_watcher.log"
+
+echo ("INFO: Listening for " + $license_path) > $logfile
+
+# Locate the VS IDE path to find the StorePID.exe
+if( $env:VS_IDE_PATH ) {
+    $VS_IDE_PATH = $env:VS_IDE_PATH
+    $env:VS_IDE_PATH = ''
+} else {
+    $VS_IDE_PATH = Split-Path -Path (Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\devenv.exe' -Name '(default)').Trim('"')
+}
+
+$VS_STOREPID_PATH = Join-Path -Path $VS_IDE_PATH -ChildPath StorePID.exe
+
+# Wait for the license file
+While( !(Test-Path $license_path) ) { sleep 1 }
+
+echo "INFO: Located license file" >> $logfile
+
+# Processing the input license data
+While( $true ) {
+    try {
+        $license = Get-Content $license_path
+        $key_code = $license.Split(" ")
+        if ( $key_code[0] -match "[^a-zA-Z0-9-]" ) { echo ("ERROR: Incorrect key" + $key_code[0]) >> $logfile; sleep 1; continue }
+        if ( $key_code[1] -match "[^0-9]" ) { echo ("ERROR: Incorrect code" + $key_code[1]) >> $logfile; sleep 1; continue }
+
+        # Execute StorePID
+        & $VS_STOREPID_PATH $key_code[0] $key_code[1]
+        if ( $LASTEXITCODE -eq 0 ) { break }
+        echo ("ERROR: Unable to store license, exit code: " + $LASTEXITCODE) >> $logfile
+    } catch { echo ("ERROR: " + $_) >> $logfile }
+    sleep 1
+}
+
+rm $license_path
+echo "INFO: The VS product license was stored" >> $logfile

--- a/playbooks/roles/visualstudio/tasks/vs.yml
+++ b/playbooks/roles/visualstudio/tasks/vs.yml
@@ -63,25 +63,61 @@
     {% if visualstudio_install_path %}--installPath "{{ visualstudio_install_path }}"{% endif %}
     --noRestart --noWeb --force --quiet --wait
 
-# The var will not be set until the install directory is defined - we don't need
-# to deal with the complicated heuristics trying to determine where installer
-# put the visual studio files
-- when: visualstudio_install_path | length > 0
-  block:
-    - name: Check the VS was installed correctly
-      win_stat:
-        path: '{{ visualstudio_install_path }}\{{ item }}'
-      with_items:
-        - Common7\IDE\devenv.exe
-        - Common7\IDE\Extensions\TestPlatform\vstest.console.exe
-        - MSBuild\Current\Bin\MSBuild.exe
-        - VC\Auxiliary\Build\vcvars64.bat
-      register: reg_stat_file
-      failed_when: not reg_stat_file.stat.exists
+# Locate devenv.exe path in registry to find the path to IDE directory
+- name: Locate VS path using registry
+  win_shell: >
+    (Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\devenv.exe'
+    -Name '(default)').Trim('"') | Split-Path | Split-Path | Split-Path
+  register: reg_vs_path
 
-    - name: Set system env variable of VS location
-      win_environment:
-        level: machine
-        state: present
-        name: VS_LOCATION
-        value: '{{ visualstudio_install_path }}'
+- name: Put the vs path to visualstudio_install_path variable
+  set_fact:
+    visualstudio_install_path: "{{ reg_vs_path.stdout_lines | first }}"
+
+- name: Check the VS was installed correctly
+  win_stat:
+    path: '{{ visualstudio_install_path }}\{{ item }}'
+  with_items:
+    - Common7\IDE\devenv.exe
+    - Common7\IDE\devenv.com
+    - Common7\IDE\StorePID.exe
+    - Common7\IDE\Extensions\TestPlatform\vstest.console.exe
+    - MSBuild\Current\Bin\MSBuild.exe
+    - VC\Auxiliary\Build\vcvars64.bat
+  register: reg_stat_file
+  failed_when: not reg_stat_file.stat.exists
+
+- name: Set system env variable of VS location
+  win_environment:
+    level: machine
+    state: present
+    name: VS_LOCATION
+    value: '{{ visualstudio_install_path }}'
+
+# Install license watcher script
+- name: Create interface directory
+  win_file:
+    path: C:\interface
+    state: directory
+
+- name: Create srv directory
+  win_file:
+    path: C:\srv
+    state: directory
+
+- name: Store vs_license_watcher script
+  win_copy:
+    src: vs_license_watcher.ps1
+    dest: C:\srv\vs_license_watcher.ps1
+
+- name: Create scheduled task to run license watcher on boot
+  win_scheduled_task:
+    name: vs_license_watcher
+    description: Run powershell script to allow users to register license for Visual Studio
+    actions:
+      - path: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        arguments: -ExecutionPolicy Unrestricted -NonInteractive -File C:\srv\vs_license_watcher.ps1
+    triggers:
+      - type: boot
+    username: SYSTEM
+    state: present

--- a/scripts/run_ansible.sh
+++ b/scripts/run_ansible.sh
@@ -22,7 +22,7 @@ pip -q install --upgrade pip wheel
 pip -q install -r "${root_dir}/requirements.txt"
 
 # Loads the override configuration for ansible
-override_yml="${root_dir}/override.yml"
+override_yml=./override.yml
 if [ -f "${override_yml}" ]; then
     override_yml="-e @${override_yml}"
 else
@@ -34,8 +34,8 @@ if [ "x$PROXY_REMOTE_LISTEN" != "x" ]; then
     proxy_remote_port=$(python3 -c "import socket, sys; sock = socket.socket(); sock.bind((sys.argv[1], 0)); print(sock.getsockname()[1]); sock.close()" "${PROXY_REMOTE_LISTEN}")
     proxy_remote_args="-e proxy_remote_host=${PROXY_REMOTE_LISTEN} -e proxy_remote_port=${proxy_remote_port}"
     echo "Running Proxy Remote on ${PROXY_REMOTE_LISTEN}:${proxy_remote_port}..."
-    python3 "${root_dir}/scripts/proxy_remote.py" "${PROXY_REMOTE_LISTEN}" "${proxy_remote_port}" &
-    trap "pkill -f '${root_dir}/scripts/proxy_remote.py' || true" EXIT
+    python3 "${root_dir}/scripts/proxy_remote.py" ${PROXY_REMOTE_LISTEN} ${proxy_remote_port} &
+    trap "pkill -f 'scripts/proxy_remote.py ${PROXY_REMOTE_LISTEN} ${proxy_remote_port}' || true" EXIT
 fi
 
 # Run the playbook

--- a/scripts/run_postprocess_docker.sh
+++ b/scripts/run_postprocess_docker.sh
@@ -13,7 +13,8 @@
 #
 # No needed to be run manually - executed by the build_image.sh script after the packer build
 
-IMAGE_FULL_PATH="$1"
+BAIT_SESSION="$1"
+IMAGE_FULL_PATH="$2"
 
 OUT_PATH=$(dirname "${IMAGE_FULL_PATH}")
 IMAGE_NAME=$(basename "${IMAGE_FULL_PATH}")
@@ -35,7 +36,7 @@ mkdir "${image_name_completed}"
 docker image save -o "${image_name_completed}/${IMAGE_NAME}.tar" "aquarium/${IMAGE_NAME}:${image_version}"
 
 echo 'INFO: Copy packer log of the build process to the image'
-cp /tmp/packer.log "${image_name_completed}/packer.log"
+cp "/tmp/bait-packer-${BAIT_SESSION}.log" "${image_name_completed}/packer.log"
 
 echo 'INFO: Put the manifest with the unpacked size of the image (in kb, whole dir first)'
 image_manifest="${image_name_completed}/${image_name_completed}.yml"

--- a/scripts/run_postprocess_native.sh
+++ b/scripts/run_postprocess_native.sh
@@ -11,7 +11,8 @@
 
 # The Native images needs packing
 
-IMAGE_FULL_PATH="$1"
+BAIT_SESSION="$1"
+IMAGE_FULL_PATH="$2"
 
 OUT_PATH=$(dirname "${IMAGE_FULL_PATH}")
 IMAGE_NAME=$(basename "${IMAGE_FULL_PATH}")
@@ -34,7 +35,7 @@ echo 'INFO: Place the environment into the image directory'
 mv "${IMAGE_FULL_PATH}.tar" "${image_name_completed}/"
 
 echo 'INFO: Copy packer log of the build process to the image dir'
-cp /tmp/packer.log "${image_name_completed}/packer.log"
+cp "/tmp/bait-packer-${BAIT_SESSION}.log" "${image_name_completed}/packer.log"
 
 echo 'INFO: Put the manifest with the unpacked size of the image (in kb, whole dir first)'
 echo "---\n# Aquarium Bait image manifest file\nsize_kb:" > "${image_name_completed}/${image_name_completed}.yml"

--- a/scripts/run_postprocess_vmx.sh
+++ b/scripts/run_postprocess_vmx.sh
@@ -13,7 +13,8 @@
 #
 # No needed to be run manually - executed by the build_image.sh script after the packer build
 
-IMAGE_FULL_PATH="$1"
+BAIT_SESSION="$1"
+IMAGE_FULL_PATH="$2"
 
 OUT_PATH=$(dirname "${IMAGE_FULL_PATH}")
 IMAGE_NAME=$(basename "${IMAGE_FULL_PATH}")
@@ -46,7 +47,7 @@ mv "${IMAGE_NAME}" "${image_name_completed}"
 disk_file_cloned=$(find "${image_name_completed}" -name 'MainDisk-1-cl*.vmdk' ! -name 'MainDisk-1-cl*-*.vmdk')
 
 echo 'INFO: Copy packer log of the build process to the image'
-cp /tmp/packer.log "${image_name_completed}/packer.log"
+cp "/tmp/bait-packer-${BAIT_SESSION}.log" "${image_name_completed}/packer.log"
 
 echo 'INFO: Put the manifest with the unpacked size of the image (in kb, whole dir first)'
 echo "---\n# Aquarium Bait image manifest file\nsize_kb:" > "${image_name_completed}/${image_name_completed}.yml"

--- a/specs/aws/ubuntu2004.yml
+++ b/specs/aws/ubuntu2004.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
   image_name: image
 
   aws_region: us-west-2
@@ -43,9 +44,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: ubuntu
-    playbook_file: playbooks/base_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes,remove_cloudinit

--- a/specs/aws/ubuntu2004/ci.yml
+++ b/specs/aws/ubuntu2004/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -48,9 +49,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: ubuntu
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes

--- a/specs/aws/winserver2019.yml
+++ b/specs/aws/winserver2019.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
   image_name: image
 
   aws_region: us-west-2
@@ -48,9 +49,9 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     user: Administrator
-    playbook_file: playbooks/base_image.yml
     use_proxy: false
     extra_arguments:
       - --skip-tags

--- a/specs/aws/winserver2019/ci.yml
+++ b/specs/aws/winserver2019/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -51,8 +52,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     # Place ansible_shell_type to the inventory to not disturb the local delegated commands
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:

--- a/specs/aws/winserver2019/vs2019.yml
+++ b/specs/aws/winserver2019/vs2019.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -51,8 +52,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/visualstudio_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/visualstudio_image.yml"
     # Place ansible_shell_type to the inventory to not disturb the local delegated commands
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:

--- a/specs/aws/winserver2019/vs2019/ci.yml
+++ b/specs/aws/winserver2019/vs2019/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -51,8 +52,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     # Place ansible_shell_type to the inventory to not disturb the local delegated commands
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:

--- a/specs/aws/winserver2022.yml
+++ b/specs/aws/winserver2022.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
   image_name: image
 
   aws_region: us-west-2
@@ -48,9 +49,9 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     user: Administrator
-    playbook_file: playbooks/base_image.yml
     use_proxy: false
     extra_arguments:
       - --skip-tags

--- a/specs/aws/winserver2022/ci.yml
+++ b/specs/aws/winserver2022/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -51,8 +52,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     # Place ansible_shell_type to the inventory to not disturb the local delegated commands
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:

--- a/specs/aws/winserver2022/vs2022.yml
+++ b/specs/aws/winserver2022/vs2022.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -51,8 +52,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/visualstudio_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/visualstudio_image.yml"
     # Place ansible_shell_type to the inventory to not disturb the local delegated commands
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:

--- a/specs/aws/winserver2022/vs2022/ci.yml
+++ b/specs/aws/winserver2022/vs2022/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   parent_name: parent_image
 
@@ -51,8 +52,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     # Place ansible_shell_type to the inventory to not disturb the local delegated commands
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:

--- a/specs/docker/ubuntu2004/ci.yml
+++ b/specs/docker/ubuntu2004/ci.yml
@@ -3,8 +3,8 @@ min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_name: parent_image
+  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
 
   # Used to mount ansible playbooks and requirements to the container

--- a/specs/docker/ubuntu2004/python3.yml
+++ b/specs/docker/ubuntu2004/python3.yml
@@ -3,8 +3,8 @@ min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_name: parent_image
+  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
 
 builders:

--- a/specs/docker/ubuntu2004/python3/ci.yml
+++ b/specs/docker/ubuntu2004/python3/ci.yml
@@ -3,8 +3,8 @@ min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_name: parent_image
+  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
 
   # Used to mount ansible playbooks and requirements to the container

--- a/specs/native/lin.yml
+++ b/specs/native/lin.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
 
@@ -16,8 +17,8 @@ provisioners:
       - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     inline:
       - >
-        ./scripts/run_ansible.sh -c local -i localhost,
+        {{ user `bait_path` }}/scripts/run_ansible.sh -c local -i localhost,
         -e ansible_become=false
         -e native_platform=lin
         -e native_init_path={{ user `out_full_path` }}/{{ user `image_name` }}
-        ./playbooks/native_base_image.yml
+        {{ user `bait_path` }}/playbooks/native_base_image.yml

--- a/specs/native/lin/ci.yml
+++ b/specs/native/lin/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
 
@@ -16,8 +17,8 @@ provisioners:
       - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     inline:
       - >
-        ./scripts/run_ansible.sh -c local -i localhost,
+        {{ user `bait_path` }}/scripts/run_ansible.sh -c local -i localhost,
         -e ansible_become=false
         -e native_platform=lin
         -e native_init_path={{ user `out_full_path` }}/{{ user `image_name` }}
-        ./playbooks/native_ci_image.yml
+        {{ user `bait_path` }}/playbooks/native_ci_image.yml

--- a/specs/native/mac.yml
+++ b/specs/native/mac.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
 
@@ -16,8 +17,8 @@ provisioners:
       - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     inline:
       - >
-        ./scripts/run_ansible.sh -c local -i localhost,
+        {{ user `bait_path` }}/scripts/run_ansible.sh -c local -i localhost,
         -e ansible_become=false
         -e native_platform=mac
         -e native_init_path={{ user `out_full_path` }}/{{ user `image_name` }}
-        ./playbooks/native_base_image.yml
+        {{ user `bait_path` }}/playbooks/native_base_image.yml

--- a/specs/native/mac/ci.yml
+++ b/specs/native/mac/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
 
@@ -16,8 +17,8 @@ provisioners:
       - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     inline:
       - >
-        ./scripts/run_ansible.sh -c local -i localhost,
+        {{ user `bait_path` }}/scripts/run_ansible.sh -c local -i localhost,
         -e ansible_become=false
         -e native_platform=mac
         -e native_init_path={{ user `out_full_path` }}/{{ user `image_name` }}
-        ./playbooks/native_ci_image.yml
+        {{ user `bait_path` }}/playbooks/native_ci_image.yml

--- a/specs/native/win.yml
+++ b/specs/native/win.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
 
@@ -16,8 +17,8 @@ provisioners:
       - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     inline:
       - >
-        ./scripts/run_ansible.sh -c local -i localhost,
+        {{ user `bait_path` }}/scripts/run_ansible.sh -c local -i localhost,
         -e ansible_become=false
         -e native_platform=win
         -e native_init_path={{ user `out_full_path` }}/{{ user `image_name` }}
-        ./playbooks/native_base_image.yml
+        {{ user `bait_path` }}/playbooks/native_base_image.yml

--- a/specs/native/win/ci.yml
+++ b/specs/native/win/ci.yml
@@ -2,6 +2,7 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
 
@@ -16,8 +17,8 @@ provisioners:
       - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     inline:
       - >
-        ./scripts/run_ansible.sh -c local -i localhost,
+        {{ user `bait_path` }}/scripts/run_ansible.sh -c local -i localhost,
         -e ansible_become=false
         -e native_platform=win
         -e native_init_path={{ user `out_full_path` }}/{{ user `image_name` }}
-        ./playbooks/native_ci_image.yml
+        {{ user `bait_path` }}/playbooks/native_ci_image.yml

--- a/specs/vmx/macos1015.yml
+++ b/specs/vmx/macos1015.yml
@@ -2,14 +2,15 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
 
-  iso_full_path: "{{ env `PWD` }}/init/iso/MacOS-Catalina-10.15.7.iso"
-  init_vmx_full_path: "{{ env `PWD` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
+  iso_full_path: "{{ user `bait_path` }}/init/iso/MacOS-Catalina-10.15.7.iso"
+  init_vmx_full_path: "{{ user `bait_path` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
 
 builders:
   - type: vmware-vmx  # vmware-iso is useless for macos installation
@@ -82,9 +83,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/base_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1015/ci.yml
+++ b/specs/vmx/macos1015/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,9 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1015/xcode122.yml
+++ b/specs/vmx/macos1015/xcode122.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/xcode_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/xcode_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1015/xcode122/ci.yml
+++ b/specs/vmx/macos1015/xcode122/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1015/xcode122/example.yml
+++ b/specs/vmx/macos1015/xcode122/example.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
+  parent_name: parent_image
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/project_example_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/project_example_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106.yml
+++ b/specs/vmx/macos1106.yml
@@ -2,14 +2,15 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
 
-  iso_full_path: "{{ env `PWD` }}/init/iso/MacOS-BigSur-11.06.4.iso"
-  init_vmx_full_path: "{{ env `PWD` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
+  iso_full_path: "{{ user `bait_path` }}/init/iso/MacOS-BigSur-11.06.4.iso"
+  init_vmx_full_path: "{{ user `bait_path` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
 
 builders:
   - type: vmware-vmx  # vmware-iso is useless for macos installation
@@ -93,9 +94,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/base_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode122.yml
+++ b/specs/vmx/macos1106/xcode122.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/xcode_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/xcode_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode122/example.yml
+++ b/specs/vmx/macos1106/xcode122/example.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/project_example_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/project_example_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode122/example/toolsci.yml
+++ b/specs/vmx/macos1106/xcode122/example/toolsci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -38,9 +39,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/project_example_toolsci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/project_example_toolsci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode131.yml
+++ b/specs/vmx/macos1106/xcode131.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/xcode_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/xcode_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode131/ci.yml
+++ b/specs/vmx/macos1106/xcode131/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode131/example.yml
+++ b/specs/vmx/macos1106/xcode131/example.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/project_example_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/project_example_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1106/xcode131/example/toolsci.yml
+++ b/specs/vmx/macos1106/xcode131/example/toolsci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -38,9 +39,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/project_example_toolsci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/project_example_toolsci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1201.yml
+++ b/specs/vmx/macos1201.yml
@@ -2,14 +2,15 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
 
-  iso_full_path: "{{ env `PWD` }}/init/iso/MacOS-Monterey-12.01.iso"
-  init_vmx_full_path: "{{ env `PWD` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
+  iso_full_path: "{{ user `bait_path` }}/init/iso/MacOS-Monterey-12.01.iso"
+  init_vmx_full_path: "{{ user `bait_path` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
 
 builders:
   - type: vmware-vmx  # vmware-iso is useless for macos installation
@@ -95,9 +96,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/base_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1201/xcode133.yml
+++ b/specs/vmx/macos1201/xcode133.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/xcode_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/xcode_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1203.yml
+++ b/specs/vmx/macos1203.yml
@@ -2,14 +2,15 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
 
-  iso_full_path: "{{ env `PWD` }}/init/iso/MacOS-Monterey-12.03.iso"
-  init_vmx_full_path: "{{ env `PWD` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
+  iso_full_path: "{{ user `bait_path` }}/init/iso/MacOS-Monterey-12.03.iso"
+  init_vmx_full_path: "{{ user `bait_path` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
 
 builders:
   - type: vmware-vmx  # vmware-iso is useless for macos installation
@@ -101,9 +102,8 @@ provisioners:
       - echo '{{ user `password` }}' | sudo -S installer -pkg /tmp/python.pkg -target /
 
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/base_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     # Use python3 installed before instead of the default not working one (/usr/bin/python3)
     # due to not installed developer tools and absent of any built-in python.
     # Using inventory here because extra_arguments are working for localhost (vncdo) too.

--- a/specs/vmx/macos1203/xcode133.yml
+++ b/specs/vmx/macos1203/xcode133.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/xcode_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/xcode_image.yml"
     # Use python3 installed before instead of the default not working one (/usr/bin/python3)
     # due to not installed developer tools and absent of any built-in python.
     # Using inventory here because extra_arguments are working for localhost (vncdo) too.

--- a/specs/vmx/macos1203/xcode133/ci.yml
+++ b/specs/vmx/macos1203/xcode133/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/macos1203/xcode133/exampleci.yml
+++ b/specs/vmx/macos1203/xcode133/exampleci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -38,9 +39,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/project_example_toolsci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/project_example_toolsci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/ubuntu2004.yml
+++ b/specs/vmx/ubuntu2004.yml
@@ -2,14 +2,15 @@
 min_packer_version: 1.7.9
 variables:
   # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
 
-  iso_full_path: "{{ env `PWD` }}/init/iso/ubuntu-20.04.4-live-server-amd64.iso"
-  init_vmx_full_path: "{{ env `PWD` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
+  iso_full_path: "{{ user `bait_path` }}/init/iso/ubuntu-20.04.4-live-server-amd64.iso"
+  init_vmx_full_path: "{{ user `bait_path` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
 
 builders:
   - type: vmware-vmx  # Use vmx init to describe the steps and control the VM parameters exactly
@@ -66,9 +67,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/base_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/ubuntu2004/build.yml
+++ b/specs/vmx/ubuntu2004/build.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/build_essential_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/build_essential_image.yml"
     ansible_env_vars:
       - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:

--- a/specs/vmx/ubuntu2004/build/ci.yml
+++ b/specs/vmx/ubuntu2004/build/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/vmx/ubuntu2004/build/macsdklibs110.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/macsdklibs_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/macsdklibs_image.yml"
     ansible_env_vars:
       - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:

--- a/specs/vmx/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/vmx/ubuntu2004/build/macsdklibs110/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/ubuntu2004/ci.yml
+++ b/specs/vmx/ubuntu2004/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,9 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    user: "{{ user `username` }}"
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}

--- a/specs/vmx/winserver2019.yml
+++ b/specs/vmx/winserver2019.yml
@@ -2,14 +2,15 @@
 min_packer_version: 1.7.9
 variables:
   # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
 
-  iso_full_path: "{{ env `PWD` }}/init/iso/Windows-Server-2019_1809.16_64Bit_English_DC_STD_MLF_X22-67487.iso"
-  init_vmx_full_path: "{{ env `PWD` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
+  iso_full_path: "{{ user `bait_path` }}/init/iso/Windows-Server-2019_1809.16_64Bit_English_DC_STD_MLF_X22-67487.iso"
+  init_vmx_full_path: "{{ user `bait_path` }}/init/vmx/{{ user `image_name` }}/{{ user `image_name` }}.vmx"
 
 builders:
   - type: vmware-vmx  # Use vmx init to describe the steps and control the VM parameters exactly
@@ -98,9 +99,9 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     user: "{{ user `username` }}"
-    playbook_file: playbooks/base_image.yml
     use_proxy: false  # For proper connection with VMWare
     extra_arguments:
       # - -e  # To work with winrm https

--- a/specs/vmx/winserver2019/ci.yml
+++ b/specs/vmx/winserver2019/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -33,8 +34,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:
       - -e

--- a/specs/vmx/winserver2019/vs2019.yml
+++ b/specs/vmx/winserver2019/vs2019.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -31,8 +32,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/visualstudio_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/visualstudio_image.yml"
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:
       - -e

--- a/specs/vmx/winserver2019/vs2019/ci.yml
+++ b/specs/vmx/winserver2019/vs2019/ci.yml
@@ -2,10 +2,11 @@
 min_packer_version: 1.7.9
 variables:
   # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
   image_name: image
+  parent_name: parent_image
   out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
-  parent_name: parent_image
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -33,8 +34,8 @@ builders:
 
 provisioners:
   - type: ansible
-    command: ./scripts/run_ansible.sh
-    playbook_file: playbooks/ci_image.yml
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     inventory_file_template: "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }} ansible_shell_type=powershell\n"
     extra_arguments:
       - -e


### PR DESCRIPTION
This change allows organization to override, track & store own changes while using the bait framework & images as much as possible.

Now it supports running custom specs, bait specs, custom ansible override.yml roles & playbooks for sure. Also pack, check style & upload scripts. Just follow the readme documentation `Overlay repository` to setup the overlay repo properly.

Also fixes some found style & other issues.

## Related Issue

fixes: #25 

## Motivation and Context

This one was a long one - previously I stored the override.yml & specs in the same bait repo untracked - but enough this nonsense now we can safely track the overlay changes.

## How Has This Been Tested?

Manually - aws, vmx & native images from overlay repo & from bait repo.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

