### PR TITLE
A number of fixes for AWS

### DIFF
--- a/playbooks/build_essential_image.yml
+++ b/playbooks/build_essential_image.yml
@@ -1,9 +1,6 @@
 ---
 - name: Build essential ubuntu image
   hosts: all
-  environment:
-    http_proxy: http://{{ proxy_remote_host }}:{{ proxy_remote_port }}
-    https_proxy: http://{{ proxy_remote_host }}:{{ proxy_remote_port }}
   roles:
     - role: build_essential
     - role: cleanup

--- a/playbooks/macsdklibs_image.yml
+++ b/playbooks/macsdklibs_image.yml
@@ -1,9 +1,6 @@
 ---
 - name: Install quite the same libs from MacOS SDK
   hosts: all
-  environment:
-    http_proxy: http://{{ proxy_remote_host }}:{{ proxy_remote_port }}
-    https_proxy: http://{{ proxy_remote_host }}:{{ proxy_remote_port }}
   roles:
     - role: macsdklibs
     - role: cleanup

--- a/playbooks/roles/build_essential/tasks/main.yml
+++ b/playbooks/roles/build_essential/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: Install build-essential and m4 packages
   become: true
+  environment:
+    # Redirecting APT requests through proxy
+    http_proxy: "{{ bait_proxy_url | default(omit) }}"
+    https_proxy: "{{ bait_proxy_url | default(omit) }}"
   apt:
     name:
       - build-essential

--- a/playbooks/roles/init/tasks/linux.yml
+++ b/playbooks/roles/init/tasks/linux.yml
@@ -20,15 +20,17 @@
     - apport  # Pings external servers
     - ubuntu-report  # Pings external servers
     - whoopsie  # Pings external servers
-    - cloud-init  # Watching on the configs and altering on boot
 
-- name: Remove unnecessary packages for local VMs
+- name: Remove not needed items from cloud-init cfg
   become: true
-  apt:
-    name: cloud-init
-    state: absent
-  tags:
-    - remove_cloudinit
+  lineinfile:
+    path: /etc/cloud/cloud.cfg
+    regexp: "^ - {{ item }}$"
+    line: " #- {{ item }}"
+  with_items:
+    - apt-configure  # Do not allow to reconfigure apt sources.list
+    - ubuntu-advantage  # We don't need any mothership calls
+    - package-update-upgrade-install  # Do not update the packages - image has to be the same
 
 - name: Disable motd news since it's fetching spam
   become: true

--- a/playbooks/roles/macsdklibs/tasks/linux.yml
+++ b/playbooks/roles/macsdklibs/tasks/linux.yml
@@ -1,6 +1,10 @@
 ---
 - name: Install MacOS SDK libs to match build env on MacOS
   become: true
+  environment:
+    # Redirecting APT requests through proxy
+    http_proxy: "{{ bait_proxy_url | default(omit) }}"
+    https_proxy: "{{ bait_proxy_url | default(omit) }}"
   apt:
     name: '{{ macsdklibs_lin_list }}'
     update_cache: true

--- a/specs/aws/ubuntu2004.yml
+++ b/specs/aws/ubuntu2004.yml
@@ -48,4 +48,4 @@ provisioners:
     playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
     extra_arguments:
       - --skip-tags
-      - wipe_disk_zeroes,remove_cloudinit
+      - wipe_disk_zeroes

--- a/specs/aws/ubuntu2004/build.yml
+++ b/specs/aws/ubuntu2004/build.yml
@@ -1,0 +1,63 @@
+---
+min_packer_version: 1.7.9
+variables:
+  # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
+  image_name: image
+  parent_name: parent_image
+
+  aws_region: us-west-2
+  aws_account_id: "{{ env `AWS_ACCOUNT_ID` }}"
+  aws_key_id: "{{ env `AWS_KEY_ID` }}"
+  aws_secret_key: "{{ env `AWS_SECRET_KEY` }}"
+
+builders:
+  - type: amazon-ebs
+    instance_type: t2.medium
+    ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
+    tags:
+      Name: "aquarium/{{ user `image_name` }}"
+
+    region: "{{ user `aws_region` }}"
+    access_key: "{{ user `aws_key_id` }}"
+    secret_key: "{{ user `aws_secret_key` }}"
+
+    source_ami_filter:
+      most_recent: true
+      owners: ["{{ user `aws_account_id` }}"]  # Required by packer for security reasons
+      filters:
+        tag:Name: "aquarium/{{ user `parent_name` }}"
+
+    # Disk
+    launch_block_device_mappings:
+      - device_name: /dev/sda1
+        volume_size: 40
+        volume_type: gp3
+        delete_on_termination: true
+
+    # Network
+    subnet_filter:
+      filters:
+        tag:Class: image-build
+      most_free: true
+
+    security_group_filter:
+      filters:
+        tag:Class: image-build-ssh
+
+    ssh_username: ubuntu
+
+    # Tunnel will transfer traffic through ssh to the http proxy for ansible
+    ssh_remote_tunnels:
+      - 1080:127.0.0.1:1080
+
+provisioners:
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/build_essential_image.yml"
+    ansible_env_vars:
+      # Start proxy on static port to use packer's ssh tunnel
+      - PROXY_REMOTE_LISTEN=127.0.0.1:1080
+    extra_arguments:
+      - --skip-tags
+      - wipe_disk_zeroes

--- a/specs/aws/ubuntu2004/build/ci.yml
+++ b/specs/aws/ubuntu2004/build/ci.yml
@@ -1,0 +1,60 @@
+---
+min_packer_version: 1.7.9
+variables:
+  # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
+  image_name: image
+  parent_name: parent_image
+
+  aws_region: us-west-2
+  aws_account_id: "{{ env `AWS_ACCOUNT_ID` }}"
+  aws_key_id: "{{ env `AWS_KEY_ID` }}"
+  aws_secret_key: "{{ env `AWS_SECRET_KEY` }}"
+
+builders:
+  - type: amazon-ebs
+    instance_type: t2.medium
+    ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
+    tags:
+      Name: "aquarium/{{ user `image_name` }}"
+
+    region: "{{ user `aws_region` }}"
+    access_key: "{{ user `aws_key_id` }}"
+    secret_key: "{{ user `aws_secret_key` }}"
+
+    source_ami_filter:
+      most_recent: true
+      owners: ["{{ user `aws_account_id` }}"]  # Required by packer for security reasons
+      filters:
+        tag:Name: "aquarium/{{ user `parent_name` }}"
+
+    # Disk
+    launch_block_device_mappings:
+      - device_name: /dev/sda1
+        volume_size: 40
+        volume_type: gp3
+        delete_on_termination: true
+
+    # Network
+    subnet_filter:
+      filters:
+        tag:Class: image-build
+      most_free: true
+
+    security_group_filter:
+      filters:
+        tag:Class: image-build-ssh
+
+    ssh_username: ubuntu
+
+provisioners:
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
+    extra_arguments:
+      - --skip-tags
+      - wipe_disk_zeroes
+      - -e
+      - jre_extract_path=/srv/jre
+      - -e
+      - jenkins_agent_config_url=http://169.254.169.254/latest/user-data

--- a/specs/aws/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/aws/ubuntu2004/build/macsdklibs110.yml
@@ -1,0 +1,63 @@
+---
+min_packer_version: 1.7.9
+variables:
+  # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
+  image_name: image
+  parent_name: parent_image
+
+  aws_region: us-west-2
+  aws_account_id: "{{ env `AWS_ACCOUNT_ID` }}"
+  aws_key_id: "{{ env `AWS_KEY_ID` }}"
+  aws_secret_key: "{{ env `AWS_SECRET_KEY` }}"
+
+builders:
+  - type: amazon-ebs
+    instance_type: t2.medium
+    ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
+    tags:
+      Name: "aquarium/{{ user `image_name` }}"
+
+    region: "{{ user `aws_region` }}"
+    access_key: "{{ user `aws_key_id` }}"
+    secret_key: "{{ user `aws_secret_key` }}"
+
+    source_ami_filter:
+      most_recent: true
+      owners: ["{{ user `aws_account_id` }}"]  # Required by packer for security reasons
+      filters:
+        tag:Name: "aquarium/{{ user `parent_name` }}"
+
+    # Disk
+    launch_block_device_mappings:
+      - device_name: /dev/sda1
+        volume_size: 40
+        volume_type: gp3
+        delete_on_termination: true
+
+    # Network
+    subnet_filter:
+      filters:
+        tag:Class: image-build
+      most_free: true
+
+    security_group_filter:
+      filters:
+        tag:Class: image-build-ssh
+
+    ssh_username: ubuntu
+
+    # Tunnel will transfer traffic through ssh to the http proxy for ansible
+    ssh_remote_tunnels:
+      - 1080:127.0.0.1:1080
+
+provisioners:
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/macsdklibs_image.yml"
+    ansible_env_vars:
+      # Start proxy on static port to use packer's ssh tunnel
+      - PROXY_REMOTE_LISTEN=127.0.0.1:1080
+    extra_arguments:
+      - --skip-tags
+      - wipe_disk_zeroes

--- a/specs/aws/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/aws/ubuntu2004/build/macsdklibs110/ci.yml
@@ -1,0 +1,60 @@
+---
+min_packer_version: 1.7.9
+variables:
+  # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
+  image_name: image
+  parent_name: parent_image
+
+  aws_region: us-west-2
+  aws_account_id: "{{ env `AWS_ACCOUNT_ID` }}"
+  aws_key_id: "{{ env `AWS_KEY_ID` }}"
+  aws_secret_key: "{{ env `AWS_SECRET_KEY` }}"
+
+builders:
+  - type: amazon-ebs
+    instance_type: t2.medium
+    ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
+    tags:
+      Name: "aquarium/{{ user `image_name` }}"
+
+    region: "{{ user `aws_region` }}"
+    access_key: "{{ user `aws_key_id` }}"
+    secret_key: "{{ user `aws_secret_key` }}"
+
+    source_ami_filter:
+      most_recent: true
+      owners: ["{{ user `aws_account_id` }}"]  # Required by packer for security reasons
+      filters:
+        tag:Name: "aquarium/{{ user `parent_name` }}"
+
+    # Disk
+    launch_block_device_mappings:
+      - device_name: /dev/sda1
+        volume_size: 40
+        volume_type: gp3
+        delete_on_termination: true
+
+    # Network
+    subnet_filter:
+      filters:
+        tag:Class: image-build
+      most_free: true
+
+    security_group_filter:
+      filters:
+        tag:Class: image-build-ssh
+
+    ssh_username: ubuntu
+
+provisioners:
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
+    extra_arguments:
+      - --skip-tags
+      - wipe_disk_zeroes
+      - -e
+      - jre_extract_path=/srv/jre
+      - -e
+      - jenkins_agent_config_url=http://169.254.169.254/latest/user-data

--- a/specs/aws/winserver2019.yml
+++ b/specs/aws/winserver2019.yml
@@ -60,5 +60,3 @@ provisioners:
       - ansible_password={{ build `Password` }}
       - -e
       - ansible_winrm_server_cert_validation=ignore
-      - -e
-      - '{"openssh_server_ports":[22,80]}'  # Use 80 port as backup for SSH in case 22 is blocked

--- a/specs/aws/winserver2019/ci.yml
+++ b/specs/aws/winserver2019/ci.yml
@@ -43,11 +43,10 @@ builders:
 
     security_group_filter:
       filters:
-        tag:Class: image-build-winrm
+        tag:Class: image-build-ssh
 
     # In the base image we're using OpenSSH for Windows
     ssh_username: Administrator
-    ssh_port: 80
     ssh_timeout: 10m
 
 provisioners:

--- a/specs/aws/winserver2019/vs2019.yml
+++ b/specs/aws/winserver2019/vs2019.yml
@@ -43,11 +43,10 @@ builders:
 
     security_group_filter:
       filters:
-        tag:Class: image-build-winrm
+        tag:Class: image-build-ssh
 
     # In the base image we're using OpenSSH for Windows
     ssh_username: Administrator
-    ssh_port: 80
     ssh_timeout: 10m
 
 provisioners:

--- a/specs/aws/winserver2019/vs2019/ci.yml
+++ b/specs/aws/winserver2019/vs2019/ci.yml
@@ -43,11 +43,10 @@ builders:
 
     security_group_filter:
       filters:
-        tag:Class: image-build-winrm
+        tag:Class: image-build-ssh
 
     # In the base image we're using OpenSSH for Windows
     ssh_username: Administrator
-    ssh_port: 80
     ssh_timeout: 10m
 
 provisioners:

--- a/specs/aws/winserver2022.yml
+++ b/specs/aws/winserver2022.yml
@@ -60,5 +60,3 @@ provisioners:
       - ansible_password={{ build `Password` }}
       - -e
       - ansible_winrm_server_cert_validation=ignore
-      - -e
-      - '{"openssh_server_ports":[22,80]}'  # Use 80 port as backup for SSH in case 22 is blocked

--- a/specs/aws/winserver2022/ci.yml
+++ b/specs/aws/winserver2022/ci.yml
@@ -43,11 +43,10 @@ builders:
 
     security_group_filter:
       filters:
-        tag:Class: image-build-winrm
+        tag:Class: image-build-ssh
 
     # In the base image we're using OpenSSH for Windows
     ssh_username: Administrator
-    ssh_port: 80
     ssh_timeout: 10m
 
 provisioners:

--- a/specs/aws/winserver2022/vs2022.yml
+++ b/specs/aws/winserver2022/vs2022.yml
@@ -43,11 +43,10 @@ builders:
 
     security_group_filter:
       filters:
-        tag:Class: image-build-winrm
+        tag:Class: image-build-ssh
 
     # In the base image we're using OpenSSH for Windows
     ssh_username: Administrator
-    ssh_port: 80
     ssh_timeout: 10m
 
 provisioners:

--- a/specs/aws/winserver2022/vs2022/ci.yml
+++ b/specs/aws/winserver2022/vs2022/ci.yml
@@ -43,11 +43,10 @@ builders:
 
     security_group_filter:
       filters:
-        tag:Class: image-build-winrm
+        tag:Class: image-build-ssh
 
     # In the base image we're using OpenSSH for Windows
     ssh_username: Administrator
-    ssh_port: 80
     ssh_timeout: 10m
 
 provisioners:


### PR DESCRIPTION
The fixes are needed to properly build the AWS ubuntu images & a bit simplify winserver images:
* Moved winserver images to default 22 ssh port for simplicity
* Fixed issue with cloud-init on AWS overriding apt sources.list
* Added a way to pass the remote proxy thru the ssh connection for AWS - now it's possible to have a communication to controlled artifact server to receive ubuntu packages and other goods for clouds.

## Related Issue

fixes: #3

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

