### PR TITLE
Added docker hostonly isolation, moved remote proxy to run by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Run docker image build validation
         run: |
+          echo '172.17.0.1 host.docker.internal' | sudo tee -a /etc/hosts
+          packer plugins install github.com/hashicorp/docker
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file": "{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
             ./build_image.sh "${spec}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,10 @@ jobs:
 
       - name: Run checkstyle
         run: ./check_style.sh
+
+      - name: Run docker image build validation
+        run: |
+          export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file": "{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
+          for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            ./build_image.sh "${spec}"
+          done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,34 @@ jobs:
 
       - name: Run docker image build validation
         run: |
+          # For some reason github doesn't want to work with --add-host option, so workaround:
           echo '172.17.0.1 host.docker.internal' | sudo tee -a /etc/hosts
+
+          # Installing necessary plugins for packer
           packer plugins install github.com/hashicorp/docker
-          export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file": "{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
+          packer plugins install github.com/hashicorp/ansible
+
+          # Change the playbook file in the packer spec to skip testing of unavailable artifacts
+          export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
+
+          # Find all the specs and sort them to build them sequentially (parent-child)
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
-            ./build_image.sh "${spec}"
+            ./build_image.sh "${spec}" | tee build.log
+
+            # Check the result in out directory is good
+            image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)
+
+            ( cd out/docker
+              # Check manifest
+              ls -lh "./${image_name}/${image_name}.yml"
+              # Check packer.log
+              ls -lh "./${image_name}/packer.log"
+              # Check saved tar archive
+              ls -lh "./${image_name}"/*.tar
+              # Check sha256 file and the content is good
+              shasum -a 256 -c "./${image_name}/${image_name}.sha256"
+            )
+
+            # Verify image packing
+            ./pack_image.sh "out/docker/${image_name}"
           done

--- a/README.md
+++ b/README.md
@@ -222,16 +222,18 @@ and could be used in playbooks/roles like:
 crashed during packer execution. For additional info look into [./build_image.sh](build_image.sh)
 and [./scripts/vncrecord.py](scripts/vncrecord.py).
 
-**NOTICE:** If you want to override spec file in runtime `yaml2json.py` script which is executed
-before the packer run can override the values of the spec. For example, you want to put
-`skip_create_ami` in amazon-ebs builder, so you can export env variable like that:
+**NOTICE:** If you want to override spec file in runtime `yaml2json.py` script, which is executed
+before the packer run, can override the values of the spec. For example, you want to put
+`skip_create_ami` in amazon-ebs builder no matter what, you can export env variable like that:
 
 ```sh
-$ export BAIT_SPEC_UPDATE='{"builders":[{"skip_create_ami":true}]}'
+$ export BAIT_SPEC_APPLY='{"builders":[{"skip_create_ami":true}]}'
 ```
 
-... before running the `build_image.sh` and it will be added to the json spec. Could be really
-useful to test the changes for example.
+... before running the `build_image.sh` and it will be added to the json spec. There are 2 more env
+vars `BAIT_SPEC_CHANGE` and `BAIT_SPEC_DELETE` in case you want just to change the value of already
+existing item (and do not add it if it's not here) and if you want to delete the part of the tree.
+Those could be really useful to test the changes for example.
 
 **NOTICE:** Parallel building is possible (really not recommended to build base images of VMX due
 to the tight VNC boot scripts timings) and have one problem with artifacts download, described in
@@ -284,6 +286,11 @@ First cloud provider integration to the images build system. It needs some knowl
 and pre-setup of the AWS project. Cloud driver also quite different from the local drivers like vmx
 or docker - it will still use the specs in packer yml format, but will store the image directly in
 AWS project.
+
+**NOTE:** Since the AMI's are updated by the OS providers - it's hard to bind to specific version
+in the base image (it could be removed or not supported by the AWS platform itself anymore). So for
+clouds we're using the latest AMI available on the build occurance and then this built base image
+could be used in the childs indefinitely.
 
 #### Usage
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -187,7 +187,7 @@ fi
 clean_bg
 
 echo "INFO:  generating packer json for '${yml}'..."
-cat "${yml}" | "${script_dir}/scripts/run_yaml2json.sh" "$BAIT_SPEC_UPDATE" > "${yml}.json"
+cat "${yml}" | "${script_dir}/scripts/run_yaml2json.sh" "$BAIT_SPEC_APPLY" "$BAIT_SPEC_CHANGE" "$BAIT_SPEC_DELETE" > "${yml}.json"
 
 if [ "$image_type" = 'vmx' ]; then
     # Cleaning the non-tracked files from the init directory

--- a/build_image.sh
+++ b/build_image.sh
@@ -127,7 +127,7 @@ if [ "$image_type" = 'docker' ]; then
     # --add-host is required here for linux docker hosts where we have it not set by default
     echo "INFO: Running isolation proxy container: bait_proxy"
     [ "$(docker images -q bait_proxy)" ] || docker build --tag bait_proxy $bait_proxy_build_opts "${script_dir}/init/docker/bait_proxy"
-    [ "$(docker ps -q -f name=bait_proxy)" ] || docker run --rm -id --cap-add=NET_ADMIN --add-host=host.docker.internal:host-gateway --name bait_proxy bait_proxy &
+    [ "$(docker ps -q -f name=bait_proxy)" ] || docker run --rm -id --cap-add=NET_ADMIN --add-host=host.docker.internal:host-gateway --name bait_proxy bait_proxy
 fi
 
 ##

--- a/init/docker/bait_proxy/Dockerfile
+++ b/init/docker/bait_proxy/Dockerfile
@@ -25,6 +25,6 @@ ENTRYPOINT sh -xc 'iptables -P INPUT DROP && \
     iptables -P FORWARD DROP && \
     iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT && \
     iptables -A OUTPUT -p udp --dport 53 -j ACCEPT && \
-    iptables -A INPUT -d $(dig host.docker.internal +short)/32 -p tcp -m tcp -j ACCEPT && \
-    iptables -A OUTPUT -d $(dig host.docker.internal +short)/32 -p tcp -m tcp -j ACCEPT && \
+    iptables -A INPUT -d $(dig host.docker.internal +short | grep -o ".*" || echo "172.17.0.1")/32 -p tcp -m tcp -j ACCEPT && \
+    iptables -A OUTPUT -d $(dig host.docker.internal +short | grep -o ".*" || echo "172.17.0.1")/32 -p tcp -m tcp -j ACCEPT && \
     cat -'

--- a/init/docker/bait_proxy/Dockerfile
+++ b/init/docker/bait_proxy/Dockerfile
@@ -1,0 +1,30 @@
+# Special container to be used as network isolation with access just to the host.docker.internal
+# It's really needed on macos, because there is no particularly good way to isolate docker builds
+# Usage:
+#   1. Build it:
+#     $ docker build --tag bait_proxy ./init/docker/bait_proxy
+#   2. Start as:
+#     $ docker run --rm -it --cap-add=NET_ADMIN --name bait_proxy bait_proxy
+#   3. Use it in another container:
+#     $ docker run --rm -it --net=container:bait_proxy ubuntu:20.04
+ARG BASE_IMAGE=ubuntu:20.04
+FROM ${BASE_IMAGE}
+
+ARG APT_URL
+ARG APT_SEC_URL
+
+# It doesn't really like the https when there is no ca-certificates soo...
+RUN ( [ -z "${APT_URL}" -a -z "${APT_SEC_URL}" ] || echo 'Acquire { https::Verify-Peer false }' > /etc/apt/apt.conf.d/99tmp-verify-peer.conf ) && \
+    ( [ -z "${APT_URL}" ] || sed -i "s|http://archive.ubuntu.com/|${APT_URL}|g" /etc/apt/sources.list ) && \
+    ( [ -z "${APT_SEC_URL}" ] || sed -i "s|http://security.ubuntu.com/|${APT_SEC_URL}|g" /etc/apt/sources.list ) && \
+    apt update && apt install -y iptables dnsutils && rm -rf /var/lib/apt/lists/*
+
+# Executing the commands to isolate the network
+ENTRYPOINT sh -xc 'iptables -P INPUT DROP && \
+    iptables -P OUTPUT DROP && \
+    iptables -P FORWARD DROP && \
+    iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT && \
+    iptables -A OUTPUT -p udp --dport 53 -j ACCEPT && \
+    iptables -A INPUT -d $(dig host.docker.internal +short)/32 -p tcp -m tcp -j ACCEPT && \
+    iptables -A OUTPUT -d $(dig host.docker.internal +short)/32 -p tcp -m tcp -j ACCEPT && \
+    cat -'

--- a/playbooks/bait_validate.yml
+++ b/playbooks/bait_validate.yml
@@ -1,0 +1,144 @@
+---
+# This playbook runs on during validation to check the build scripts is ok, connection to the
+# machine is possible and the proxy is working correctly as well as download role.
+
+- name: Bait internal validation playbook
+  hosts: all
+
+  pre_tasks:
+    ##
+    # Test 1 & 2: Ensure isolation & remote proxy are working correctly
+    ##
+    - name: Execute on POSIX (Mac/Lin)
+      when: ansible_system != 'Win32NT'
+      block:
+        - name: Check it's possible to request http://google.com through remote proxy
+          environment:
+            # Redirecting requests through proxy
+            http_proxy: '{{ bait_proxy_url | default(omit) }}'
+            https_proxy: '{{ bait_proxy_url | default(omit) }}'
+          uri:
+            url: http://google.com
+            follow_redirects: none
+            timeout: 5
+            status_code: 301
+
+        - name: Install ca-certificates for linux to validate remote
+          become: true
+          environment:
+            # Redirecting APT requests through proxy
+            http_proxy: "{{ bait_proxy_url | default(omit) }}"
+            https_proxy: "{{ bait_proxy_url | default(omit) }}"
+          apt:
+            update_cache: true
+            name:
+              - ca-certificates
+
+        - name: Check it's possible to request https://google.com through remote proxy
+          environment:
+            # Redirecting requests through proxy
+            http_proxy: '{{ bait_proxy_url | default(omit) }}'
+            https_proxy: '{{ bait_proxy_url | default(omit) }}'
+          uri:
+            url: https://google.com
+            follow_redirects: none
+            timeout: 5
+            status_code: 301
+
+        - name: Check it's impossible to request google.com without remote proxy
+          uri:
+            url: http://google.com
+            follow_redirects: none
+            timeout: 5
+            status_code: -1
+
+    - name: Execute on Windows
+      when: ansible_system == 'Win32NT'
+      block:
+        - name: Check it's possible to request http://google.com through remote proxy
+          environment:
+            # Redirecting requests through proxy
+            http_proxy: '{{ bait_proxy_url | default(omit) }}'
+            https_proxy: '{{ bait_proxy_url | default(omit) }}'
+          win_uri:
+            url: http://google.com
+            follow_redirects: none
+            timeout: 5
+            status_code: 301
+
+        - name: Check it's possible to request https://google.com through remote proxy
+          environment:
+            # Redirecting requests through proxy
+            http_proxy: '{{ bait_proxy_url | default(omit) }}'
+            https_proxy: '{{ bait_proxy_url | default(omit) }}'
+          win_uri:
+            url: https://google.com
+            follow_redirects: none
+            timeout: 5
+            status_code: 301
+
+        - name: Check it's impossible to request google.com without remote proxy
+          win_uri:
+            url: http://google.com
+            follow_redirects: none
+            timeout: 5
+            status_code: -1
+
+    ##
+    # Test 3: Ensure download role working correctly
+    ##
+    - set_fact:
+        reference_file_sum: sha256:6a5c56b5123cd8266e6c1cd290199dcd1d37fa7a3f48309acecc3526dc402cdb
+
+    - name: Download the reference README.md file to the environment
+      include_role:
+        name: download
+      vars:
+        download_url: http://not-existing-server/reference/README.md
+        download_sum: '{{ reference_file_sum }}'
+
+    - name: Execute on POSIX (Mac/Lin)
+      when: ansible_system != 'Win32NT'
+      block:
+        - name: Make sure file exists and have desired checksum
+          stat:
+            path: '{{ download_path }}'
+            checksum_algorithm: '{{ (reference_file_sum.split(":") | first) }}'
+          register: reg_reference_file
+          failed_when: reg_reference_file.stat.checksum != (reference_file_sum.split(":") | last)
+
+    - name: Execute on Windows
+      when: ansible_system == 'Win32NT'
+      block:
+        - name: Make sure file exists and have desired checksum
+          win_stat:
+            path: '{{ download_path }}'
+            checksum_algorithm: '{{ reference_file_sum.split(":") | first }}'
+          register: reg_reference_file
+          failed_when: reg_reference_file.stat.checksum != (reference_file_sum.split(":") | last)
+
+  roles:
+    ##
+    # Test 4: Verify cleanup is working properly
+    ##
+    - role: cleanup
+
+  post_tasks:
+    # Reference file should be cleaned up
+    - name: Execute on POSIX (Mac/Lin)
+      when: ansible_system != 'Win32NT'
+      block:
+        - name: Verify the reference file does not exist anymore
+          stat:
+            path: '{{ download_path }}'
+          register: reg_reference_file
+          failed_when: reg_reference_file.stat.exists
+
+    - name: Execute on Windows
+      when: ansible_system == 'Win32NT'
+      block:
+        - name: Verify the reference file does not exist anymore
+          win_stat:
+            path: '{{ download_path }}'
+          register: reg_reference_file
+          failed_when: reg_reference_file.stat.exists

--- a/playbooks/bait_validate.yml
+++ b/playbooks/bait_validate.yml
@@ -12,6 +12,11 @@
     - name: Execute on POSIX (Mac/Lin)
       when: ansible_system != 'Win32NT'
       block:
+        - name: Store build identifier to allow the layer to contain something
+          copy:
+            dest: /bait_id.txt
+            content: '{{ lookup("env", "BAIT_SESSION") }}'
+
         - name: Check it's possible to request http://google.com through remote proxy
           environment:
             # Redirecting requests through proxy
@@ -55,6 +60,11 @@
     - name: Execute on Windows
       when: ansible_system == 'Win32NT'
       block:
+        - name: Store build identifier to allow the layer to contain something
+          win_copy:
+            dest: C:\bait_id.txt
+            content: '{{ lookup("env", "BAIT_SESSION") }}'
+
         - name: Check it's possible to request http://google.com through remote proxy
           environment:
             # Redirecting requests through proxy

--- a/playbooks/files/lin/README.md
+++ b/playbooks/files/lin/README.md
@@ -1,0 +1,5 @@
+# OS download files
+
+This is the directory for specific platform files that is used as cache in `download` role.
+
+Also it's used as reference file to test download role in `playbooks/bait_verify.yml`.

--- a/playbooks/files/mac/README.md
+++ b/playbooks/files/mac/README.md
@@ -1,0 +1,5 @@
+# OS download files
+
+This is the directory for specific platform files that is used as cache in `download` role.
+
+Also it's used as reference file to test download role in `playbooks/bait_verify.yml`.

--- a/playbooks/files/win/README.md
+++ b/playbooks/files/win/README.md
@@ -1,0 +1,5 @@
+# OS download files
+
+This is the directory for specific platform files that is used as cache in `download` role.
+
+Also it's used as reference file to test download role in `playbooks/bait_verify.yml`.

--- a/scripts/proxy_local.py
+++ b/scripts/proxy_local.py
@@ -127,7 +127,7 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         port = int(sys.argv[1])
     with ThreadingTCPServer(('127.0.0.1', port), SocksProxy) as server:
-        print("PROXYL: Started Aquarium Bait noroute proxy on %s %s" % server.server_address)
+        print("PROXYL: Started Aquarium Bait noroute proxy on %s:%d" % server.server_address)
         try:
             server.serve_forever()
         except KeyboardInterrupt:

--- a/scripts/run_ansible.sh
+++ b/scripts/run_ansible.sh
@@ -26,26 +26,10 @@ else
     unset override_yml
 fi
 
-# Run the proxy_remote script to listen on the provided address and random free port on the host
-# Value need to be the address `host:port` or just `host` available for the remote to connect to
-if [ "x$PROXY_REMOTE_LISTEN" != "x" ]; then
-    if [ "x$(echo "${PROXY_REMOTE_LISTEN}:" | cut -d: -f2)" = 'x' ]; then
-        # Generate random port
-        proxy_remote_port=$(python3 -c 'import socket, sys; sock = socket.socket(); sock.bind((sys.argv[1], 0)); print(sock.getsockname()[1]); sock.close()' "${PROXY_REMOTE_LISTEN}")
-        PROXY_REMOTE_LISTEN="$(echo "$PROXY_REMOTE_LISTEN" | cut -d: -f1):${proxy_remote_port}"
-    fi
-    proxy_remote_args="-e bait_proxy_url=http://${PROXY_REMOTE_LISTEN}"
-
-    echo "Running Proxy Remote on http://${PROXY_REMOTE_LISTEN} ..."
-    script="scripts/proxy_remote.py $(echo "$PROXY_REMOTE_LISTEN" | tr ':' ' ')"
-    python3 "${bait_dir}"/$script &
-    trap "pkill -f '$script' || true" EXIT
-fi
-
 # Run the playbook
 if [ "x$DEBUG" != "x" ]; then
-    echo -- "${bait_dir}/.venv/bin/ansible-playbook" -vvv $proxy_remote_args $override_yml "$@"
-    "${bait_dir}/.venv/bin/ansible-playbook" -vvv $proxy_remote_args $override_yml "$@"
+    echo -- "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml "$@"
+    "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml "$@"
 else
-    "${bait_dir}/.venv/bin/ansible-playbook" $proxy_remote_args $override_yml "$@"
+    "${bait_dir}/.venv/bin/ansible-playbook" $override_yml "$@"
 fi

--- a/scripts/run_ansible.sh
+++ b/scripts/run_ansible.sh
@@ -18,9 +18,6 @@ bait_dir=$(dirname "$(dirname "$0")")
 # Setup virtual env for ansible
 . "${bait_dir}/scripts/require_venv.sh"
 
-check=
-[ -z "$ANSIBLE_DRY_RUN" ] || check=--check
-
 # Loads the override configuration for ansible
 override_yml=./override.yml
 if [ -f "${override_yml}" ]; then
@@ -31,8 +28,8 @@ fi
 
 # Run the playbook
 if [ "x$DEBUG" != "x" ]; then
-    echo -- "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml $check "$@"
-    "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml $check "$@"
+    echo -- "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml "$@"
+    "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml "$@"
 else
-    "${bait_dir}/.venv/bin/ansible-playbook" $override_yml $check "$@"
+    "${bait_dir}/.venv/bin/ansible-playbook" $override_yml "$@"
 fi

--- a/scripts/run_ansible.sh
+++ b/scripts/run_ansible.sh
@@ -18,6 +18,9 @@ bait_dir=$(dirname "$(dirname "$0")")
 # Setup virtual env for ansible
 . "${bait_dir}/scripts/require_venv.sh"
 
+check=
+[ -z "$ANSIBLE_DRY_RUN" ] || check=--check
+
 # Loads the override configuration for ansible
 override_yml=./override.yml
 if [ -f "${override_yml}" ]; then
@@ -28,8 +31,8 @@ fi
 
 # Run the playbook
 if [ "x$DEBUG" != "x" ]; then
-    echo -- "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml "$@"
-    "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml "$@"
+    echo -- "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml $check "$@"
+    "${bait_dir}/.venv/bin/ansible-playbook" -vvv $override_yml $check "$@"
 else
-    "${bait_dir}/.venv/bin/ansible-playbook" $override_yml "$@"
+    "${bait_dir}/.venv/bin/ansible-playbook" $override_yml $check "$@"
 fi

--- a/scripts/run_postprocess_aws.sh
+++ b/scripts/run_postprocess_aws.sh
@@ -9,6 +9,17 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-# The AWS images are already good as is and don't need a post-processing
+# The AWS images are already good as is and doesn't need a post-processing, but needs to
+# report the image name anyway
 
-echo "INFO: Image post-process completed."
+BAIT_SESSION="$1"
+IMAGE_FULL_PATH="$2"
+
+IMAGE_NAME=$(basename "${IMAGE_FULL_PATH}")
+
+root_dir="$PWD"
+
+# Getting AMI name from the packer log
+image_name_completed=$(grep "^==> amazon-ebs: Prevalidating AMI Name:" "${root_dir}/logs/bait-${IMAGE_NAME}-packer-${BAIT_SESSION}.log" | rev | cut -d" " -f -1 | rev)
+
+echo "INFO: Image post-process completed: ${image_name_completed}"

--- a/scripts/yaml2json.py
+++ b/scripts/yaml2json.py
@@ -10,39 +10,69 @@
 # governing permissions and limitations under the License.
 
 # Script to convert easy-to-read yaml format to packer-acceptable json one with a bit of
-# processing in the middle to simplify our life as developers. You can provide update_json
-# as the first argument to merge in.yml data and update_json together.
+# processing in the middle to simplify our life as developers. You can provide 3 additional
+# arguments to the script to alter the data:
+#  * apply_json - will forcefully apply the described json to the in.yml effectively overriding it
+#  * change_json - will only change if the value exists in the in.yml data, otherwise will skip it
+#  * delete_json - will delete the described values from the in.yml data tree
 #
 # Usage:
-#   $ cat in.yml | ./yaml2json.py [update_json] > out.json
+#   $ cat in.yml | ./yaml2json.py [add_json [change_json [delete_json]]] > out.json
 
 import sys, yaml, json
 
 # Simple merger for dict/list data
-def merge(data, update):
+# * data - input data to change
+# * update - data to apply/change/delete
+# * operation - "a", "c" or "d"
+def merge(data, update, operation):
     items = update.items() if isinstance(update, dict) else enumerate(update)
     for k, v in items:
         if isinstance(v, dict) or isinstance(v, list):
             data_val = data.get(k, None) if isinstance(data, dict) else (data[k] if len(data) > k else None)
             if data_val == None:
-                if isinstance(data, list) and len(data) <= k:
-                    data.append(v)
-                else:
-                    data[k] = v
+                # Data value is not here
+                if operation == 'a':  # Apply anyway
+                    if isinstance(data, list) and len(data) <= k:
+                        data.append(v)
+                    else:
+                        data[k] = v
+                # Change & delete are not needed here - the value doesn't exist
             else:
+                # Data value is here
                 if isinstance(data_val, dict) or isinstance(data_val, list):
-                    data[k] = merge(data_val, v)
+                    data[k] = merge(data_val, v, operation)
                 else:
-                    data[k] = v
+                    if operation == 'd':  # Need to delete
+                        if k in data:
+                            del data[k]
+                    else:
+                        data[k] = v
         else:
-            data[k] = v
+            # The item of update is not the type for iteration
+            if operation == 'd':  # Deleting only if it's the last key in update
+                if k in data:
+                    del data[k]
+            elif operation == 'a':  # Applying the data or change if key exists
+                data[k] = v
+            elif operation == 'c':
+                data_val = data.get(k, None) if isinstance(data, dict) else (data[k] if len(data) > k else None)
+                if data_val != None:
+                    data[k] = v
     return data
 
 
 data = yaml.safe_load(sys.stdin.read())
 
+# Apply / Change / Delete data from the input yaml
 if len(sys.argv) > 1 and sys.argv[1] != '':
-    update = json.loads(sys.argv[1])
-    data = merge(data, update)
+    apply = json.loads(sys.argv[1])
+    data = merge(data, apply, 'a')
+if len(sys.argv) > 2 and sys.argv[2] != '':
+    change = json.loads(sys.argv[2])
+    data = merge(data, change, 'c')
+if len(sys.argv) > 3 and sys.argv[3] != '':
+    delete = json.loads(sys.argv[3])
+    data = merge(data, delete, 'd')
 
 print(json.dumps(data))

--- a/specs/aws/ubuntu2004.yml
+++ b/specs/aws/ubuntu2004.yml
@@ -22,7 +22,14 @@ builders:
     secret_key: "{{ user `aws_secret_key` }}"
 
     # https://cloud-images.ubuntu.com/locator/ec2/
-    source_ami: ami-00bb3d0b5b36e89b8  # Release 20220810
+    # For AWS it seems unreasonable to bind to specific version of the OS AMI (often removed)
+    source_ami_filter:
+      filters:
+        virtualization-type: hvm
+        root-device-type: ebs
+        name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+      owners: ["099720109477"]  # Ubuntu
+      most_recent: true
 
     # Disk
     launch_block_device_mappings:

--- a/specs/aws/ubuntu2004.yml
+++ b/specs/aws/ubuntu2004.yml
@@ -4,6 +4,7 @@ variables:
   # Variables are set by the build_image.sh script based on the spec path
   bait_path: .
   image_name: image
+  remote_proxy_port: '1080'
 
   aws_region: us-west-2
   aws_key_id: "{{ env `AWS_KEY_ID` }}"
@@ -49,3 +50,5 @@ provisioners:
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}

--- a/specs/aws/ubuntu2004/build.yml
+++ b/specs/aws/ubuntu2004/build.yml
@@ -56,9 +56,8 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/build_essential_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}

--- a/specs/aws/ubuntu2004/build/ci.yml
+++ b/specs/aws/ubuntu2004/build/ci.yml
@@ -56,12 +56,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/aws/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/aws/ubuntu2004/build/macsdklibs110.yml
@@ -56,9 +56,8 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/macsdklibs_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}

--- a/specs/aws/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/aws/ubuntu2004/build/macsdklibs110/ci.yml
@@ -56,12 +56,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/aws/ubuntu2004/ci.yml
+++ b/specs/aws/ubuntu2004/ci.yml
@@ -56,12 +56,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/aws/ubuntu2204.yml
+++ b/specs/aws/ubuntu2204.yml
@@ -4,6 +4,7 @@ variables:
   # Variables are set by the build_image.sh script based on the spec path
   bait_path: .
   image_name: image
+  remote_proxy_port: '1080'
 
   aws_region: us-west-2
   aws_key_id: "{{ env `AWS_KEY_ID` }}"
@@ -49,3 +50,5 @@ provisioners:
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}

--- a/specs/aws/ubuntu2204.yml
+++ b/specs/aws/ubuntu2204.yml
@@ -22,7 +22,14 @@ builders:
     secret_key: "{{ user `aws_secret_key` }}"
 
     # https://cloud-images.ubuntu.com/locator/ec2/
-    source_ami: ami-0aa5fa88fa2ec19dc  # Release 20230216
+    # For AWS it seems unreasonable to bind to specific version of the OS AMI (often removed)
+    source_ami_filter:
+      filters:
+        virtualization-type: hvm
+        root-device-type: ebs
+        name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*
+      owners: ["099720109477"]  # Ubuntu
+      most_recent: true
 
     # Disk
     launch_block_device_mappings:

--- a/specs/aws/ubuntu2204/build.yml
+++ b/specs/aws/ubuntu2204/build.yml
@@ -56,9 +56,8 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/build_essential_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}

--- a/specs/aws/ubuntu2204/build/ci.yml
+++ b/specs/aws/ubuntu2204/build/ci.yml
@@ -56,12 +56,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/aws/ubuntu2204/build/macsdklibs110.yml
+++ b/specs/aws/ubuntu2204/build/macsdklibs110.yml
@@ -56,9 +56,8 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/macsdklibs_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}

--- a/specs/aws/ubuntu2204/build/macsdklibs110/ci.yml
+++ b/specs/aws/ubuntu2204/build/macsdklibs110/ci.yml
@@ -56,12 +56,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/aws/ubuntu2204/ci.yml
+++ b/specs/aws/ubuntu2204/ci.yml
@@ -56,12 +56,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      # Start proxy on static port to use packer's ssh tunnel
-      - PROXY_REMOTE_LISTEN=127.0.0.1:{{ user `remote_proxy_port` }}
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - bait_proxy_url=http://127.0.0.1:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/aws/winserver2019.yml
+++ b/specs/aws/winserver2019.yml
@@ -21,8 +21,7 @@ builders:
     secret_key: "{{ user `aws_secret_key` }}"
 
     # https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#LaunchInstances:
-    # source_ami: ami-01aeb1044bb7cb673  # Release Windows_Server-2019-English-Full-Base-2023.01.19
-    # Unfortunately AWS removes the old windows AMI's, so we have to use the filter...
+    # For AWS it seems unreasonable to bind to specific version of the OS AMI (often removed)
     source_ami_filter:
       filters:
         virtualization-type: hvm

--- a/specs/aws/winserver2022.yml
+++ b/specs/aws/winserver2022.yml
@@ -21,8 +21,7 @@ builders:
     secret_key: "{{ user `aws_secret_key` }}"
 
     # https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#LaunchInstances:
-    # source_ami: ami-0e2daa9ce776be2b0  # Release Windows_Server-2022-English-Full-Base-2023.01.19
-    # Unfortunately AWS removes the old windows AMI's, so we have to use the filter...
+    # For AWS it seems unreasonable to bind to specific version of the OS AMI (often removed)
     source_ami_filter:
       filters:
         virtualization-type: hvm

--- a/specs/docker/ubuntu2004.yml
+++ b/specs/docker/ubuntu2004.yml
@@ -4,15 +4,24 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: ubuntu:20.04
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
 
 provisioners:
   # Install python3 to connect by ansible from host machine in child images
   - type: shell
+    env:
+      https_proxy: http://host.docker.internal:{{ user `remote_proxy_port` }}
     inline:
       - apt update
       # Installing python for ansible

--- a/specs/docker/ubuntu2004.yml
+++ b/specs/docker/ubuntu2004.yml
@@ -12,6 +12,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2004.yml
+++ b/specs/docker/ubuntu2004.yml
@@ -21,6 +21,7 @@ provisioners:
   # Install python3 to connect by ansible from host machine in child images
   - type: shell
     env:
+      http_proxy: http://host.docker.internal:{{ user `remote_proxy_port` }}
       https_proxy: http://host.docker.internal:{{ user `remote_proxy_port` }}
     inline:
       - apt update

--- a/specs/docker/ubuntu2004/build.yml
+++ b/specs/docker/ubuntu2004/build.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
 
 provisioners:
   - type: ansible
@@ -22,6 +29,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
 
     # SCP is not working on OpenSSH client >9
     use_sftp: true

--- a/specs/docker/ubuntu2004/build.yml
+++ b/specs/docker/ubuntu2004/build.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2004/build/ci.yml
+++ b/specs/docker/ubuntu2004/build/ci.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
     changes:
       # Locale is important during compilation
       - ENV LANG en_US.UTF-8
@@ -32,6 +39,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/docker/ubuntu2004/build/ci.yml
+++ b/specs/docker/ubuntu2004/build/ci.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/docker/ubuntu2004/build/macsdklibs110.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
 
 provisioners:
   - type: ansible
@@ -22,6 +29,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
 
     # SCP is not working on OpenSSH client >9
     use_sftp: true

--- a/specs/docker/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/docker/ubuntu2004/build/macsdklibs110.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/docker/ubuntu2004/build/macsdklibs110/ci.yml
@@ -4,17 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
-
-  # Used to mount ansible playbooks and requirements to the container
-  aquarium_path: "{{ env `PWD` }}"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
     changes:
       # Locale is important during compilation
       - ENV LANG en_US.UTF-8
@@ -35,6 +39,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/docker/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/docker/ubuntu2004/build/macsdklibs110/ci.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2004/ci.yml
+++ b/specs/docker/ubuntu2004/ci.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
     changes:
       # Locale is important during compilation
       - ENV LANG en_US.UTF-8
@@ -32,6 +39,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/docker/ubuntu2004/ci.yml
+++ b/specs/docker/ubuntu2004/ci.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2204.yml
+++ b/specs/docker/ubuntu2204.yml
@@ -12,6 +12,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --
@@ -26,7 +27,7 @@ provisioners:
     inline:
       - apt update
       # Installing python for ansible
-      - apt install -y python3 python3-apt python-is-python3
+      - apt install -y python3 python-is-python3
       # Installing sftp server to use it in ansible to copy files back and forth (OpenSSH client >9)
       - apt install -y --no-install-recommends openssh-sftp-server
       # Cleanup

--- a/specs/docker/ubuntu2204.yml
+++ b/specs/docker/ubuntu2204.yml
@@ -4,15 +4,24 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: ubuntu:22.04
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
 
 provisioners:
   # Install python3 to connect by ansible from host machine in child images
   - type: shell
+    env:
+      https_proxy: http://host.docker.internal:{{ user `remote_proxy_port` }}
     inline:
       - apt update
       # Installing python for ansible

--- a/specs/docker/ubuntu2204.yml
+++ b/specs/docker/ubuntu2204.yml
@@ -21,11 +21,12 @@ provisioners:
   # Install python3 to connect by ansible from host machine in child images
   - type: shell
     env:
+      http_proxy: http://host.docker.internal:{{ user `remote_proxy_port` }}
       https_proxy: http://host.docker.internal:{{ user `remote_proxy_port` }}
     inline:
       - apt update
       # Installing python for ansible
-      - apt install -y python3 python-is-python3
+      - apt install -y python3 python3-apt python-is-python3
       # Installing sftp server to use it in ansible to copy files back and forth (OpenSSH client >9)
       - apt install -y --no-install-recommends openssh-sftp-server
       # Cleanup

--- a/specs/docker/ubuntu2204/build.yml
+++ b/specs/docker/ubuntu2204/build.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
 
 provisioners:
   - type: ansible
@@ -22,6 +29,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
 
     # SCP is not working on OpenSSH client >9
     use_sftp: true

--- a/specs/docker/ubuntu2204/build.yml
+++ b/specs/docker/ubuntu2204/build.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2204/build/ci.yml
+++ b/specs/docker/ubuntu2204/build/ci.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
     changes:
       # Locale is important during compilation
       - ENV LANG en_US.UTF-8
@@ -32,6 +39,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/docker/ubuntu2204/build/ci.yml
+++ b/specs/docker/ubuntu2204/build/ci.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2204/build/macsdklibs110.yml
+++ b/specs/docker/ubuntu2204/build/macsdklibs110.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
 
 provisioners:
   - type: ansible
@@ -22,6 +29,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
 
     # SCP is not working on OpenSSH client >9
     use_sftp: true

--- a/specs/docker/ubuntu2204/build/macsdklibs110.yml
+++ b/specs/docker/ubuntu2204/build/macsdklibs110.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2204/build/macsdklibs110/ci.yml
+++ b/specs/docker/ubuntu2204/build/macsdklibs110/ci.yml
@@ -4,17 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
-
-  # Used to mount ansible playbooks and requirements to the container
-  aquarium_path: "{{ env `PWD` }}"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
     changes:
       # Locale is important during compilation
       - ENV LANG en_US.UTF-8
@@ -35,6 +39,8 @@ provisioners:
       - wipe_disk_zeroes
       - -e
       - ansible_become=false  # We already root here
+      - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
       - -e

--- a/specs/docker/ubuntu2204/build/macsdklibs110/ci.yml
+++ b/specs/docker/ubuntu2204/build/macsdklibs110/ci.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/docker/ubuntu2204/ci.yml
+++ b/specs/docker/ubuntu2204/ci.yml
@@ -40,6 +40,8 @@ provisioners:
       - -e
       - ansible_become=false  # We already root here
       - -e
+      - bait_proxy_url=http://host.docker.internal:{{ user `remote_proxy_port` }}
+      - -e
       - jre_extract_path=/srv/jre
       - -e
       - jenkins_agent_config_url=https://host.docker.internal:8001/meta/v1/data/?format=env

--- a/specs/docker/ubuntu2204/ci.yml
+++ b/specs/docker/ubuntu2204/ci.yml
@@ -4,14 +4,21 @@ variables:
   # All the variables are set by the build_image.sh script based on the path
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
 
 builders:
   - type: docker
     image: "aquarium/{{ user `parent_name` }}:{{ user `parent_version` }}"
     pull: false
     commit: true
+    run_command:
+      - -dit
+      - --net=container:bait_proxy  # Host only access
+      - --entrypoint=/bin/sh
+      - --
+      - "{{.Image}}"
     changes:
       # Locale is important during compilation
       - ENV LANG en_US.UTF-8

--- a/specs/docker/ubuntu2204/ci.yml
+++ b/specs/docker/ubuntu2204/ci.yml
@@ -15,6 +15,7 @@ builders:
     commit: true
     run_command:
       - -dit
+      - -u=0  # Using root user
       - --net=container:bait_proxy  # Host only access
       - --entrypoint=/bin/sh
       - --

--- a/specs/vmx/ubuntu2004.yml
+++ b/specs/vmx/ubuntu2004.yml
@@ -5,6 +5,7 @@ variables:
   bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -69,11 +70,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - vmtools_vm_type=vmware
 

--- a/specs/vmx/ubuntu2004/build.yml
+++ b/specs/vmx/ubuntu2004/build.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/build_essential_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
 
     # scp causes issues while running on OpenSSH client >9
     use_sftp: true

--- a/specs/vmx/ubuntu2004/build/ci.yml
+++ b/specs/vmx/ubuntu2004/build/ci.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
 

--- a/specs/vmx/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/vmx/ubuntu2004/build/macsdklibs110.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/macsdklibs_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
 
     # scp causes issues while running on OpenSSH client >9
     use_sftp: true

--- a/specs/vmx/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/vmx/ubuntu2004/build/macsdklibs110/ci.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
 

--- a/specs/vmx/ubuntu2004/ci.yml
+++ b/specs/vmx/ubuntu2004/ci.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
 

--- a/specs/vmx/ubuntu2204.yml
+++ b/specs/vmx/ubuntu2204.yml
@@ -5,6 +5,7 @@ variables:
   bait_path: .
   image_name: image
   out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -70,11 +71,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - vmtools_vm_type=vmware
 

--- a/specs/vmx/ubuntu2204/build.yml
+++ b/specs/vmx/ubuntu2204/build.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/build_essential_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
 
     # scp causes issues while running on OpenSSH client >9
     use_sftp: true

--- a/specs/vmx/ubuntu2204/build/ci.yml
+++ b/specs/vmx/ubuntu2204/build/ci.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
 

--- a/specs/vmx/ubuntu2204/build/macsdklibs110.yml
+++ b/specs/vmx/ubuntu2204/build/macsdklibs110.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/macsdklibs_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
 
     # scp causes issues while running on OpenSSH client >9
     use_sftp: true

--- a/specs/vmx/ubuntu2204/build/macsdklibs110/ci.yml
+++ b/specs/vmx/ubuntu2204/build/macsdklibs110/ci.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
 

--- a/specs/vmx/ubuntu2204/ci.yml
+++ b/specs/vmx/ubuntu2204/ci.yml
@@ -5,8 +5,9 @@ variables:
   bait_path: .
   image_name: image
   parent_name: parent_image
-  out_full_path: "{{ env `PWD` }}/out"
   parent_full_path: "{{ user `out_full_path` }}/parent_image-version"
+  out_full_path: "{{ env `PWD` }}/out"
+  remote_proxy_port: '1080'
   aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
   username: packer
   password: packer
@@ -34,11 +35,11 @@ provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
     playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
-    ansible_env_vars:
-      - PROXY_REMOTE_LISTEN={{ build `PackerHTTPIP` }}
     extra_arguments:
       - -e
       - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - bait_proxy_url=http://{{ build `PackerHTTPIP` }}:{{ user `remote_proxy_port` }}
       - -e
       - jre_extract_path=/srv/jre
 


### PR DESCRIPTION
Changes:
* Docker: Proper hostonly network isolation for docker images
* CI: Added actual build / pack on linux host - very helpful with validation of the build scripts, proxies & isolation verification
* AWS: Unified the post actions to report the image name just as the other providers
* Proxy: rewrote remote proxy to properly handle http connections - before it failed trying to pass them
* Updated README documentation

BREAKING:
* Build: Removed not needed `PROXY_REMOTE_LISTEN` and used direct set of `bait_proxy_url` instead for simplicity
   * Moved remote proxy to build_image.sh in order to allow to use it without ansible if needed (docker base images for example)
* AWS: Moved to rolling images for linux to unify it for the cloud providers. You still can have solid state, but starting from your base images
* Build: Improved packer spec alteration merger - now it's more flexible

## Related Issue

fixes: #37 
related: #31 

## Motivation and Context

Finally got struck on how to fix that issue

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

