### PR TITLE
CI: MacOS check runner and proper creation of win jenkins profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,9 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
+          echo "Build jobs to process: $(find ./specs/docker -name '*.yml' | wc -l)"
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            echo "::group::./build_image.sh ${spec}"
             ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
@@ -46,6 +48,7 @@ jobs:
 
             # Verify image packing
             ./pack_image.sh "out/docker/${image_name}"
+            echo "::endgroup::"
           done
 
   Check-Mac-Desktop:
@@ -69,7 +72,9 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
+          echo "Build jobs to process: $(find ./specs/docker -name '*.yml' | wc -l)"
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            echo "::group::./build_image.sh ${spec}"
             ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
@@ -88,6 +93,7 @@ jobs:
 
             # Verify image packing
             ./pack_image.sh "out/docker/${image_name}"
+            echo "::endgroup::"
           done
 
   Check-Mac-Colima:
@@ -112,7 +118,9 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
+          echo "Build jobs to process: $(find ./specs/docker -name '*.yml' | wc -l)"
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            echo "::group::./build_image.sh ${spec}"
             ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
@@ -131,4 +139,5 @@ jobs:
 
             # Verify image packing
             ./pack_image.sh "out/docker/${image_name}"
+            echo "::endgroup::"
           done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,9 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
+          echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            echo "Processing ${spec}"
             ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
@@ -124,7 +126,9 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
+          echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            echo "Processing ${spec}"
             ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
             echo "Processing ${spec}"
-            ./build_image.sh "${spec}" # | tee build.log
+            sh -ex ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
             image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)
@@ -117,7 +117,7 @@ jobs:
           echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
             echo "Processing ${spec}"
-            ./build_image.sh "${spec}" # | tee build.log
+            sh -ex ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
             image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
   Check-Lin:
     runs-on: ubuntu-latest
     steps:
+      - name: Show used docker version
+        run: docker version
+
       - uses: actions/checkout@v3
 
       - name: Run checkstyle
@@ -49,13 +52,95 @@ jobs:
             ./pack_image.sh "out/docker/${image_name}"
           done
 
-  Check-Mac:
+  Check-Mac-Desktop:
     runs-on: macos-12
     steps:
-    - uses: docker-practice/actions-setup-docker@master
-      timeout-minutes: 12
+      - name: Setup Docker Desktop
+        uses: docker-practice/actions-setup-docker@master
+        timeout-minutes: 12
 
-    - run: |
-        set -x
-        docker version
-        docker run --rm hello-world
+      - name: Show used docker version
+        run: docker version
+
+      - uses: actions/checkout@v3
+
+      - name: Run checkstyle
+        run: ./check_style.sh
+
+      - name: Run docker image build validation
+        run: |
+          # Installing necessary plugins for packer
+          packer plugins install github.com/hashicorp/docker
+          packer plugins install github.com/hashicorp/ansible
+
+          # Change the playbook file in the packer spec to skip testing of unavailable artifacts
+          export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
+
+          # Find all the specs and sort them to build them sequentially (parent-child)
+          for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            ./build_image.sh "${spec}" | tee build.log
+
+            # Check the result in out directory is good
+            image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)
+
+            ( cd out/docker
+              # Check manifest
+              ls -lh "./${image_name}/${image_name}.yml"
+              # Check packer.log
+              ls -lh "./${image_name}/packer.log"
+              # Check saved tar archive
+              ls -lh "./${image_name}"/*.tar
+              # Check sha256 file and the content is good
+              shasum -a 256 -c "./${image_name}/${image_name}.sha256"
+            )
+
+            # Verify image packing
+            ./pack_image.sh "out/docker/${image_name}"
+          done
+
+  Check-Mac-Colima:
+    runs-on: macos-12
+    steps:
+      - name: Setup Docker Colima
+        run: |
+          brew install docker
+          colima start
+
+      - name: Show used docker version
+        run: docker version
+
+      - uses: actions/checkout@v3
+
+      - name: Run checkstyle
+        run: ./check_style.sh
+
+      - name: Run docker image build validation
+        run: |
+          # Installing necessary plugins for packer
+          packer plugins install github.com/hashicorp/docker
+          packer plugins install github.com/hashicorp/ansible
+
+          # Change the playbook file in the packer spec to skip testing of unavailable artifacts
+          export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
+
+          # Find all the specs and sort them to build them sequentially (parent-child)
+          for spec in $(find ./specs/docker -name '*.yml' | sort); do
+            ./build_image.sh "${spec}" | tee build.log
+
+            # Check the result in out directory is good
+            image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)
+
+            ( cd out/docker
+              # Check manifest
+              ls -lh "./${image_name}/${image_name}.yml"
+              # Check packer.log
+              ls -lh "./${image_name}/packer.log"
+              # Check saved tar archive
+              ls -lh "./${image_name}"/*.tar
+              # Check sha256 file and the content is good
+              shasum -a 256 -c "./${image_name}/${image_name}.sha256"
+            )
+
+            # Verify image packing
+            ./pack_image.sh "out/docker/${image_name}"
+          done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  Check:
+  Check-Lin:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,3 +48,14 @@ jobs:
             # Verify image packing
             ./pack_image.sh "out/docker/${image_name}"
           done
+
+  Check-Mac:
+    runs-on: macos-12
+    steps:
+    - uses: docker-practice/actions-setup-docker@master
+      timeout-minutes: 12
+
+    - run: |
+        set -x
+        docker version
+        docker run --rm hello-world

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,6 @@ jobs:
           # For some reason github doesn't want to work with --add-host option, so workaround:
           echo '172.17.0.1 host.docker.internal' | sudo tee -a /etc/hosts
 
-          # Installing necessary plugins for packer
-          packer plugins install github.com/hashicorp/docker
-          packer plugins install github.com/hashicorp/ansible
-
           # Change the playbook file in the packer spec to skip testing of unavailable artifacts
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
@@ -69,10 +65,6 @@ jobs:
 
       - name: Run docker image build validation
         run: |
-          # Installing necessary plugins for packer
-          packer plugins install github.com/hashicorp/docker
-          packer plugins install github.com/hashicorp/ansible
-
           # Change the playbook file in the packer spec to skip testing of unavailable artifacts
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
@@ -118,10 +110,6 @@ jobs:
 
       - name: Run docker image build validation
         run: |
-          # Installing necessary plugins for packer
-          packer plugins install github.com/hashicorp/docker
-          packer plugins install github.com/hashicorp/ansible
-
           # Change the playbook file in the packer spec to skip testing of unavailable artifacts
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
             echo "Processing ${spec}"
-            ./build_image.sh "${spec}" | tee build.log
+            ./build_image.sh "${spec}" # | tee build.log
 
             # Check the result in out directory is good
             image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)
@@ -117,7 +117,7 @@ jobs:
           echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
             echo "Processing ${spec}"
-            ./build_image.sh "${spec}" | tee build.log
+            ./build_image.sh "${spec}" # | tee build.log
 
             # Check the result in out directory is good
             image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,10 +69,8 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
-          echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
-            echo "Processing ${spec}"
-            sh -ex ./build_image.sh "${spec}" | tee build.log
+            ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
             image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)
@@ -114,10 +112,8 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
-          echo 'Running sequential build process'
           for spec in $(find ./specs/docker -name '*.yml' | sort); do
-            echo "Processing ${spec}"
-            sh -ex ./build_image.sh "${spec}" | tee build.log
+            ./build_image.sh "${spec}" | tee build.log
 
             # Check the result in out directory is good
             image_name=$(grep 'INFO: Image post-process completed:' build.log | rev | cut -d " " -f -1 | rev)

--- a/build_image.sh
+++ b/build_image.sh
@@ -22,7 +22,7 @@ script_dir="$PWD"
 cd "${root_dir}"
 
 # Used to separate different builds on the same machine
-export BAIT_SESSION=$(LC_ALL=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
+export BAIT_SESSION=$(dd bs=1024 if=/dev/urandom count=1 2>/dev/null | LC_ALL=C tr -dc a-zA-Z0-9 | head -c 8)
 
 # Disable packer auto-update calls
 export CHECKPOINT_DISABLE=1

--- a/playbooks/roles/jenkins_agent/tasks/windows.yml
+++ b/playbooks/roles/jenkins_agent/tasks/windows.yml
@@ -36,17 +36,9 @@
     path: "{{ jenkins_agent_path }}"
     state: directory
 
-- name: Create log directory
-  win_file:
-    path: C:\Users\jenkins
-    state: directory
-
-- name: Add jenkins home dir allow rights
-  win_acl:
-    path: C:\Users\jenkins
-    user: jenkins
-    rights: FullControl
-    type: allow
+- name: Create user profile dirs
+  win_user_profile:
+    username: jenkins
 
 - name: Store disk formatall script
   win_copy:
@@ -59,8 +51,8 @@
     name: formatall
     working_directory: C:\
     application: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-    stdout_file: C:\Users\jenkins\formatall.log
-    stderr_file: C:\Users\jenkins\formatall.log
+    stdout_file: C:\tmp\formatall.log
+    stderr_file: C:\tmp\formatall.log
     arguments:
       - -ExecutionPolicy
       - Bypass


### PR DESCRIPTION
* MacOS GitHub actions runners with Docker Desktop & Colima distributions. Found that on GH actions the tee will not break the pipe when read is complete and will read forever, so used dd instead of direct ingestion.
* BUGFIX: windows jenkins user now have a proper profile directory, otherwise service start created another directory with added host name. Also it could be related to the tmp directory issues in VS.

## Related Issue

related: #31 

## Motivation and Context

Just for fun

## How Has This Been Tested?

Automatically

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

