### PR TITLE
Added child macos images for AWS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Setup Docker Desktop
         uses: docker-practice/actions-setup-docker@master
-        timeout-minutes: 12
+        timeout-minutes: 22
 
       - name: Show used docker version
         run: docker version

--- a/playbooks/download_file_cache.yml
+++ b/playbooks/download_file_cache.yml
@@ -3,7 +3,8 @@
 # Run it as: ./scripts/run_ansible.sh playbooks/download_file_cache.yml
 #
 # This playbook has one additional requirement: the download variables should be named as:
-#   `<ROLE>_[*_]<PLATFORM>_download_url` and `<ROLE>_[*_]<PLATFORM>_download_sum`
+#   * `<ROLE>_[*_]<PLATFORM>[_<ARCH>]_download_url`
+#   * `<ROLE>_[*_]<PLATFORM>[_<ARCH>]_download_sum`
 #
 # It will automatically skip the roles with not changed `artifact-storage/aquarium` url's.
 #
@@ -43,7 +44,7 @@
       set_fact:
         urls_to_download: >
           {{ vars | dict2items
-          | selectattr("key", "regex", "(_lin|_mac|_win)_download_url$")
+          | selectattr("key", "regex", "(_lin|_mac|_win)(_[^_]+)?_download_url$")
           | rejectattr("value", "regex", "^https://artifact-storage/aquarium/files")
           | list | items2dict }}
 
@@ -58,7 +59,7 @@
       vars:
         download_url: '{{ item.value }}'
         download_sum: '{{ vars[item.key | regex_replace("_url$", "_sum")] }}'
-        # Covering just host platforms here and storing 3rd from end item which is platform
-        download_lin_dir: '{{ item.key.split("_")[-3] }}'
-        download_mac_dir: '{{ item.key.split("_")[-3] }}'
+        # The platform could be -3 or -4 item (if optional arch is used) so filtering here by known platforms
+        download_lin_dir: '{{ item.key.split("_")[-4:-2] | intersect(["lin","win","mac"]) | first }}'
+        download_mac_dir: '{{ item.key.split("_")[-4:-2] | intersect(["lin","win","mac"]) | first }}'
       with_dict: '{{ urls_to_download }}'

--- a/playbooks/roles/download/tasks/linux.yml
+++ b/playbooks/roles/download/tasks/linux.yml
@@ -2,7 +2,7 @@
 - name: Set fact with downloaded file for use from caller role
   set_fact:
     # noqa var-naming
-    '{{ download_result_var }}': '{% if inventory_hostname == "localhost" %}{{ playbook_dir }}/files/{{ download_mac_dir }}{% else %}{{ download_lin_tmp }}{% endif %}/{{ download_url | basename }}'
+    '{{ download_result_var }}': '{% if inventory_hostname == "localhost" %}{{ playbook_dir }}/files/{{ download_lin_dir }}{% else %}{{ download_lin_tmp }}{% endif %}/{{ download_url | basename }}'
     download_local_path: '{{ playbook_dir }}/files/{{ download_lin_dir }}/{{ download_url | basename }}'
 
 - name: Create download directory

--- a/playbooks/roles/jenkins_agent/tasks/macos.yml
+++ b/playbooks/roles/jenkins_agent/tasks/macos.yml
@@ -127,6 +127,7 @@
     mode: "0644"
   vars:
     java_home: "{{ jenkins_agent_java_home }}"
+    config_url: "{{ jenkins_agent_config_url }}"
     script_path: "{{ jenkins_agent_path }}/jenkins_agent.sh"
 
 - name: Store mountall executable scripts

--- a/specs/aws/macos1206/xcode133.yml
+++ b/specs/aws/macos1206/xcode133.yml
@@ -55,9 +55,19 @@ builders:
 provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
-    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
+    playbook_file: "{{ user `bait_path` }}/playbooks/xcode_image.yml"
     user: ec2-user
     use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - xcode_download_url={% print xcode_version_133_mac_download_url %}
+      - -e
+      - xcode_download_sum={% print xcode_version_133_mac_download_sum %}
+      - -e
+      - xcode_cmd_download_url={% print xcode_version_133_cmd_mac_download_url %}
+      - -e
+      - xcode_cmd_download_sum={% print xcode_version_133_cmd_mac_download_sum %}
+      - -e
+      - xcode_extraction_timeout=14400

--- a/specs/aws/macos1206/xcode133/ci.yml
+++ b/specs/aws/macos1206/xcode133/ci.yml
@@ -55,9 +55,18 @@ builders:
 provisioners:
   - type: ansible
     command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
-    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
     user: ec2-user
     use_proxy: false
     extra_arguments:
       - --skip-tags
       - wipe_disk_zeroes
+      - -e
+      - jre_extract_path=/opt/srv/jre
+      - -e
+      - jenkins_agent_config_url=http://169.254.169.254/latest/user-data
+      # Using arm package for jre
+      - -e
+      - jre_mac_download_url={% print jre_mac_arm_download_url %}
+      - -e
+      - jre_mac_download_sum={% print jre_mac_arm_download_sum %}


### PR DESCRIPTION
## Description

Added the AWS MacOSX images for arm platform. Also had need to add optional arch to the url's so a bit changed download playbook to account for that. It just adds a way to specify arch after platform.

## How Has This Been Tested?

Manually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

