### PR TITLE
Prepared the working AWS macos CI image with autoformat/mount

### DIFF
--- a/playbooks/roles/jenkins_agent/files/lin/formatall.sh
+++ b/playbooks/roles/jenkins_agent/files/lin/formatall.sh
@@ -32,7 +32,7 @@ for disk in $to_format; do
     ) | fdisk "$disk"
 
     # Creating the filesystem
-    mkfs -t ext4 -L "workspace$counter" "${disk}p1" || mkfs -t ext4 -L "workspace$counter" "${disk}1"
+    mkfs -t ext4 -L "ws$counter" "${disk}p1" || mkfs -t ext4 -L "ws$counter" "${disk}1"
 
     # Call partprobe to notify the system that the partition table was changed
     partprobe

--- a/playbooks/roles/jenkins_agent/files/lin/mountall.sh
+++ b/playbooks/roles/jenkins_agent/files/lin/mountall.sh
@@ -27,6 +27,7 @@ for i in $(seq 1 20); do
         fi
         mount | grep "^$disk"
     done
+
     sleep $i
 done
 

--- a/playbooks/roles/jenkins_agent/files/mac/formatall.sh
+++ b/playbooks/roles/jenkins_agent/files/mac/formatall.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Detects the raw disks (without partitions), formats and mounts them
+
+# It takes some time for VMX MacOS to fill the disks list, so repeating it
+# 55 sec to process the physical disks
+for i in $(seq 1 10); do
+    # List physical disks devices paths with suffix "internal" or "external"
+    disks_type=$(diskutil list physical | grep '^/dev' | tr -d '(,):' | cut -d' ' -f 1-2 | tr ' ' '-' | grep 'internal\|external')
+
+    # Filter only no partition disks
+    to_format=''
+    for disk_type in $disks_type; do
+        disk=$(echo "$disk_type" | cut -d'-' -f 1)
+        partitioned=$(diskutil info -plist "$disk" | plutil -extract Content raw -)
+
+        # Empty if not partitioned, otherwise - type of partition scheme
+        if [ "x$partitioned" = "x" ]; then
+            to_format="$disk_type $to_format"
+        fi
+    done
+
+    # Internal disks doesn't need much and available for regular user
+    for disk_type in $to_format; do
+        disk=$(echo "$disk_type" | cut -d'-' -f 1)
+        type=$(echo "$disk_type" | cut -d'-' -f 2)
+
+        echo "Formatting & mounting disk '$disk'..."
+        # External disks mounts are prohibited by SIP to be used by a regular UI user - "operation not permitted"
+        # So using a workaround in creating dmg image and mounting it instead
+        if [ "x$type" = "xexternal" ]; then
+            # Using MBR here to not create EFI partition
+            diskutil eraseDisk HFS+ "disk_ws$counter" MBR "${disk}"
+
+            size=$(df -h "/Volumes/disk_ws$counter" | tail -1 | awk '{print $2}')
+            echo "Creating ws_image ($size) file on '$disk'..."
+            hdiutil create -o /Volumes/disk_ws$counter/ws_image -size "$size" -volname "ws$counter" -type SPARSEBUNDLE -fs HFS+ -attach
+        else
+            # Using MBR here to not create EFI partition
+            diskutil eraseDisk HFS+ "ws$counter" MBR "${disk}"
+
+            # We need to set owner to allow non-UI jenkins user to write to the disk
+            diskutil enableOwnership "/Volumes/ws$counter"
+            chown jenkins:jenkins "/Volumes/ws$counter"
+        fi
+
+        counter=$(($counter+1))
+    done
+
+    if [ "x$to_format" != "x" ]; then
+        echo "Disabling Spotlight for all the mounted volumes"
+        # Unfortunately with enabled SIP it's hard to disable spotlight for specific volume
+        mdutil -a -i off
+    fi
+
+    sleep $i
+done

--- a/playbooks/roles/jenkins_agent/files/win/jenkins_agent.ps1
+++ b/playbooks/roles/jenkins_agent/files/win/jenkins_agent.ps1
@@ -142,16 +142,6 @@ if( "$JENKINS_HTTPS_INSECURE" -eq "true" ) {
     [System.Net.ServicePointManager]::CertificatePolicy = $default_cp;
 }
 
-# Wait for jenkins response
-While( $true ) {
-    $code = try { (Invoke-WebRequest "${JENKINS_URL}").StatusCode } catch { $_.Exception.Response.StatusCode.Value__ }
-    if( $code -eq 200 -or $code -eq 403 ) {
-        break
-    }
-    echo "Wait for '${JENKINS_URL}' jenkins response..."
-    sleep 5
-}
-
 # Go into custom workspace directory if it's set
 if( "${JENKINS_AGENT_WORKSPACE}" ) {
     While( $true ) {
@@ -163,6 +153,16 @@ if( "${JENKINS_AGENT_WORKSPACE}" ) {
         echo "Wait for '${JENKINS_AGENT_WORKSPACE}' dir available..."
         sleep 5
     }
+}
+
+# Wait for jenkins response
+While( $true ) {
+    $code = try { (Invoke-WebRequest "${JENKINS_URL}").StatusCode } catch { $_.Exception.Response.StatusCode.Value__ }
+    if( $code -eq 200 -or $code -eq 403 ) {
+        break
+    }
+    echo "Wait for '${JENKINS_URL}' jenkins response..."
+    sleep 5
 }
 
 # Download the agent jar and connect to jenkins

--- a/playbooks/roles/jenkins_agent/tasks/macos.yml
+++ b/playbooks/roles/jenkins_agent/tasks/macos.yml
@@ -34,7 +34,7 @@
     group: wheel
     mode: "0755"
 
-- when: jenkins_agent_ui
+- when: jenkins_agent_ui | bool
   tags: jenkins_agent_service_config
   block:
     - name: Making jenkins user to autologin
@@ -82,7 +82,7 @@
     - name: Wait for sudo to be available
       command: sudo --stdin echo ok
       args:
-        stdin: '{{ ansible_sudo_pass }}'
+        stdin: '{{ ansible_sudo_pass | default("") }}'
       retries: 20  # sudo could take a while to complete this become
       delay: 10
       register: reg_result
@@ -116,7 +116,7 @@
       command: sudo -u jenkins defaults -currentHost write com.apple.loginwindow TALLogoutSavesState 0
 
 - name: Store LaunchDaemon plist file for agent autorun during system startup
-  when: not jenkins_agent_ui
+  when: not jenkins_agent_ui | bool
   tags: jenkins_agent_service_config
   become: true
   template:
@@ -130,22 +130,29 @@
     config_url: "{{ jenkins_agent_config_url }}"
     script_path: "{{ jenkins_agent_path }}/jenkins_agent.sh"
 
-- name: Store mountall executable scripts
+- name: Store disk scripts
   become: true
   copy:
-    src: mac/mountall.sh
-    dest: "{{ jenkins_agent_path }}/mountall.sh"
+    src: mac/{{ item }}.sh
+    dest: "{{ jenkins_agent_path }}/{{ item }}.sh"
     owner: root
     group: wheel
     mode: "0755"
+  loop:
+    - mountall
+    - formatall
 
-- name: Store service plist file for mountall autorun
+- name: Store service plist files for scripts autorun
   become: true
   template:
-    src: aquarium.ci.mountall.plist.j2
-    dest: /Library/LaunchDaemons/aquarium.ci.mountall.plist
+    src: aquarium.ci.script.plist.j2
+    dest: /Library/LaunchDaemons/aquarium.ci.{{ item }}.plist
     owner: root
     group: wheel
     mode: "0644"
   vars:
-    script_path: "{{ jenkins_agent_path }}/mountall.sh"
+    script_name: "{{ item }}"
+    script_path: "{{ jenkins_agent_path }}/{{ item }}.sh"
+  loop:
+    - mountall
+    - formatall

--- a/playbooks/roles/jenkins_agent/tasks/windows.yml
+++ b/playbooks/roles/jenkins_agent/tasks/windows.yml
@@ -74,8 +74,8 @@
     name: jenkins_agent
     working_directory: C:\Users\jenkins
     application: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-    stdout_file: C:\Users\jenkins\jenkins_agent.log
-    stderr_file: C:\Users\jenkins\jenkins_agent.log
+    stdout_file: C:\Users\jenkins\agent.log
+    stderr_file: C:\Users\jenkins\agent.log
     arguments:
       - -ExecutionPolicy
       - Bypass

--- a/playbooks/roles/jenkins_agent/templates/aquarium.ci.agent.plist.j2
+++ b/playbooks/roles/jenkins_agent/templates/aquarium.ci.agent.plist.j2
@@ -34,8 +34,8 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>/Users/jenkins/agent_out.log</string>
+    <string>/Users/jenkins/agent.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/jenkins/agent_err.log</string>
+    <string>/Users/jenkins/agent.log</string>
 </dict>
 </plist>

--- a/playbooks/roles/jenkins_agent/templates/aquarium.ci.script.plist.j2
+++ b/playbooks/roles/jenkins_agent/templates/aquarium.ci.script.plist.j2
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>aquarium.ci.mountall</string>
+    <string>aquarium.ci.{{ script_name }}</string>
 
     <key>Program</key>
     <string>{{ script_path }}</string>
@@ -14,8 +14,8 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/var/log/mountall_out.log</string>
+    <string>/var/log/{{ script_name }}.log</string>
     <key>StandardErrorPath</key>
-    <string>/var/log/mountall_err.log</string>
+    <string>/var/log/{{ script_name }}.log</string>
 </dict>
 </plist>

--- a/specs/aws/macos1206/ci.yml
+++ b/specs/aws/macos1206/ci.yml
@@ -1,0 +1,72 @@
+---
+min_packer_version: 1.7.9
+variables:
+  # Variables are set by the build_image.sh script based on the spec path
+  bait_path: .
+  image_name: image
+
+  aws_region: us-west-2
+  aws_key_id: "{{ env `AWS_KEY_ID` }}"
+  aws_secret_key: "{{ env `AWS_SECRET_KEY` }}"
+
+builders:
+  - type: amazon-ebs
+    instance_type: mac2.metal
+    ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
+    tags:
+      Name: "aquarium/{{ user `image_name` }}"
+
+    region: "{{ user `aws_region` }}"
+    access_key: "{{ user `aws_key_id` }}"
+    secret_key: "{{ user `aws_secret_key` }}"
+
+    # https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#LaunchInstances:
+    # For AWS it seems unreasonable to bind to specific version of the OS AMI (often removed)
+    source_ami_filter:
+      filters:
+        virtualization-type: hvm
+        root-device-type: ebs
+        name: amzn-ec2-macos-12.6.*-arm64
+      owners: ["887450438545"]  # Amazon
+      most_recent: true
+
+    # Disk
+    launch_block_device_mappings:
+      - device_name: /dev/sda1
+        volume_size: 200
+        volume_type: gp3
+        delete_on_termination: true
+
+    # Network
+    subnet_filter:
+      most_free: true
+      filters:
+        tag:Class: image-build
+
+    security_group_filter:
+      filters:
+        tag:Class: image-build-ssh
+
+    tenancy: host
+
+    ssh_username: ec2-user
+    ssh_timeout: 15m
+
+provisioners:
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
+    user: ec2-user
+    use_proxy: false
+    extra_arguments:
+      - --skip-tags
+      - wipe_disk_zeroes
+      - -e
+      - jre_extract_path=/opt/srv/jre
+      - -e
+      - jenkins_agent_config_url=http://169.254.169.254/latest/user-data
+      # Using arm package for jre
+      - -e
+      - jre_mac_download_url={% print jre_mac_arm_download_url %}
+      - -e
+      - jre_mac_download_sum={% print jre_mac_arm_download_sum %}

--- a/specs/vmx/macos1015/ci.yml
+++ b/specs/vmx/macos1015/ci.yml
@@ -40,8 +40,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly (DIBR-4244)
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1015/xcode122/ci.yml
+++ b/specs/vmx/macos1015/xcode122/ci.yml
@@ -40,8 +40,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1106/ci.yml
+++ b/specs/vmx/macos1106/ci.yml
@@ -40,8 +40,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1106/xcode122/example/toolsci.yml
+++ b/specs/vmx/macos1106/xcode122/example/toolsci.yml
@@ -48,7 +48,7 @@ provisioners:
       - -e
       - jre_extract_path=/opt/srv/jre
       - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
+      - jenkins_agent_ui=true  # In case your tests needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1106/xcode131/ci.yml
+++ b/specs/vmx/macos1106/xcode131/ci.yml
@@ -40,8 +40,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1106/xcode131/example/toolsci.yml
+++ b/specs/vmx/macos1106/xcode131/example/toolsci.yml
@@ -48,7 +48,7 @@ provisioners:
       - -e
       - jre_extract_path=/opt/srv/jre
       - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
+      - jenkins_agent_ui=true  # In case your tests needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1203/ci.yml
+++ b/specs/vmx/macos1203/ci.yml
@@ -46,8 +46,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly (DIBR-4244)
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1203/xcode133/ci.yml
+++ b/specs/vmx/macos1203/xcode133/ci.yml
@@ -46,8 +46,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly (DIBR-4244)
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1203/xcode133/exampleci.yml
+++ b/specs/vmx/macos1203/xcode133/exampleci.yml
@@ -48,7 +48,7 @@ provisioners:
       - -e
       - jre_extract_path=/opt/srv/jre
       - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
+      - jenkins_agent_ui=true  # In case your tests needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1303/ci.yml
+++ b/specs/vmx/macos1303/ci.yml
@@ -46,8 +46,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly (DIBR-4244)
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1303/xcode143/ci.yml
+++ b/specs/vmx/macos1303/xcode143/ci.yml
@@ -46,8 +46,6 @@ provisioners:
       - ansible_sudo_pass={{ user `password` }}
       - -e
       - jre_extract_path=/opt/srv/jre
-      - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly (DIBR-4244)
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9

--- a/specs/vmx/macos1303/xcode143/exampleci.yml
+++ b/specs/vmx/macos1303/xcode143/exampleci.yml
@@ -48,7 +48,7 @@ provisioners:
       - -e
       - jre_extract_path=/opt/srv/jre
       - -e
-      - jenkins_agent_ui=true  # MacOS needs UI to work properly
+      - jenkins_agent_ui=true  # In case your tests needs UI to work properly
 
     # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
     # which causes issues while running on OpenSSH client >9


### PR DESCRIPTION
This change completes basic macos AWS integration by adding formatall/mountall scripts which works with both UI and non-UI jenkins agent.
* BREAKING: Changed autoformat workspace to "ws" (both lin & mac)
* Checking workspace access before connecting outside
* Made macos jenkins agent script similar to linux one
* Better logging to the same file
* Minimal CI images on macos should not use UI to use volumes

## How Has This Been Tested?

Manually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

