### PR TITLE
Switched to better network/disk/cpu c6a.large with just 2x price

### DIFF
--- a/specs/aws/ubuntu2004.yml
+++ b/specs/aws/ubuntu2004.yml
@@ -12,7 +12,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2004/build.yml
+++ b/specs/aws/ubuntu2004/build.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2004/build/ci.yml
+++ b/specs/aws/ubuntu2004/build/ci.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2004/build/macsdklibs110.yml
+++ b/specs/aws/ubuntu2004/build/macsdklibs110.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2004/build/macsdklibs110/ci.yml
+++ b/specs/aws/ubuntu2004/build/macsdklibs110/ci.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2004/ci.yml
+++ b/specs/aws/ubuntu2004/ci.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2204.yml
+++ b/specs/aws/ubuntu2204.yml
@@ -12,7 +12,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2204/build.yml
+++ b/specs/aws/ubuntu2204/build.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2204/build/ci.yml
+++ b/specs/aws/ubuntu2204/build/ci.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2204/build/macsdklibs110.yml
+++ b/specs/aws/ubuntu2204/build/macsdklibs110.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2204/build/macsdklibs110/ci.yml
+++ b/specs/aws/ubuntu2204/build/macsdklibs110/ci.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/ubuntu2204/ci.yml
+++ b/specs/aws/ubuntu2204/ci.yml
@@ -14,7 +14,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2019.yml
+++ b/specs/aws/winserver2019.yml
@@ -11,7 +11,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2019/ci.yml
+++ b/specs/aws/winserver2019/ci.yml
@@ -13,7 +13,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2019/vs2019.yml
+++ b/specs/aws/winserver2019/vs2019.yml
@@ -13,7 +13,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2019/vs2019/ci.yml
+++ b/specs/aws/winserver2019/vs2019/ci.yml
@@ -13,7 +13,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2022.yml
+++ b/specs/aws/winserver2022.yml
@@ -11,7 +11,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2022/ci.yml
+++ b/specs/aws/winserver2022/ci.yml
@@ -13,7 +13,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2022/vs2022.yml
+++ b/specs/aws/winserver2022/vs2022.yml
@@ -13,7 +13,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"

--- a/specs/aws/winserver2022/vs2022/ci.yml
+++ b/specs/aws/winserver2022/vs2022/ci.yml
@@ -13,7 +13,7 @@ variables:
 
 builders:
   - type: amazon-ebs
-    instance_type: t3.medium
+    instance_type: c6a.large
     ami_name: "aquarium/{{ user `image_name` }}-{{ isotime `060102.150405` }}"
     tags:
       Name: "aquarium/{{ user `image_name` }}"


### PR DESCRIPTION
vs2022 showed that build running for > 5h and by simple switching to more performant c6a.large we can get up to 5x boost for 2x price, so the end price could be ~$0.17 (1h) per build instead of ~$0.3 (5h).

## Motivation and Context

Money & time

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

