### PR TITLE
Initial tart builder for mac + ci. Still lacks of packaging of the image

### DIFF
--- a/playbooks/roles/init/tasks/macos.yml
+++ b/playbooks/roles/init/tasks/macos.yml
@@ -9,8 +9,9 @@
   include_tasks: macos_systemsetup.yml
   vars:
     key: "{{ item }}"
-    value: Never
+    value: 0
   with_items:
+    - sleep
     - computersleep
     - displaysleep
     - harddisksleep
@@ -56,6 +57,14 @@
     host: currentHost
     domain: com.apple.screensaver
     key: idleTime
+    type: int
+    value: 0
+
+- name: Disable screensaver on login window
+  become: true
+  osx_defaults:
+    domain: com.apple.screensaver
+    key: loginWindowIdleTime
     type: int
     value: 0
 

--- a/playbooks/roles/init/tasks/macos_systemsetup.yml
+++ b/playbooks/roles/init/tasks/macos_systemsetup.yml
@@ -5,12 +5,6 @@
 # * value - value to set
 
 
-- name: Get the current {{ key }}
-  command: systemsetup -get{{ key }}
-  become: true
-  register: reg_key
-
 - name: Set {{ key }} to {{ value }}
   command: systemsetup -set{{ key }} {{ value }}
-  when: not reg_key.stdout.endswith(value)
   become: true

--- a/playbooks/roles/jre/defaults/main.yml
+++ b/playbooks/roles/jre/defaults/main.yml
@@ -5,6 +5,8 @@ jre_lin_tar_suffix: --strip-components=1
 
 jre_mac_download_url: https://artifact-storage/aquarium/files/mac/zulu8.58.0.14-sa-jre8.0.312-macosx_x64.tar.gz
 jre_mac_download_sum: sha256:cb945aa49ea1747eea217fd1c9bf26040790ffecc64a8070e7c408cd15161dbb
+jre_mac_arm_download_url: https://artifact-storage/aquarium/files/mac/zulu11.52.14-sa-jre11.0.13-macosx_aarch64.tar.gz
+jre_mac_arm_download_sum: sha256:cb68c6bb0a98fb9d9dccab70895ec6e35351ab00bda4d71dc2fbd3f5325adaba
 jre_mac_tar_suffix: --strip-components=4
 
 jre_win_download_url: https://artifact-storage/aquarium/files/win/zulu8.58.0.14-sa-jre8.0.312-win_x64.tar.gz

--- a/scripts/run_postprocess_tart.sh
+++ b/scripts/run_postprocess_tart.sh
@@ -1,0 +1,67 @@
+#!/bin/sh -e
+# Copyright 2024 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+# The Tart images are not supporting proper linked clone functionality, so we're going to
+# use tar incremental archives to keep the child images small and require parent for unpack
+
+BAIT_SESSION="$1"
+IMAGE_FULL_PATH="$2"
+
+OUT_PATH=$(dirname "${IMAGE_FULL_PATH}")
+IMAGE_NAME=$(basename "${IMAGE_FULL_PATH}")
+
+root_dir="$PWD"
+cd "${OUT_PATH}"
+
+# Getting the timestamp of the VM for proper versioning
+vm_timestamp=$(for f in "$HOME/.tart/vms/${IMAGE_NAME}"/*; do date -ur "$f" +%y%m%d.%H%M%S; done | sort | tail -1)
+image_name_completed="${IMAGE_NAME}-${vm_timestamp}"
+
+echo 'INFO: Changing name of the VM to append the timestamp'
+tart rename "${IMAGE_NAME}" "${image_name_completed}"
+
+echo 'INFO: Creating new image directory'
+mkdir -p "${image_name_completed}"
+
+echo 'INFO: Copy packer log of the build process to the image'
+cp "${root_dir}/logs/bait-${IMAGE_NAME}-packer-${BAIT_SESSION}.log" "${image_name_completed}/packer.log"
+
+echo 'INFO: Put the manifest with the unpacked size of the image (in kb, whole dir first)'
+echo "---\n# Aquarium Bait image manifest file\nsize_kb:" > "${image_name_completed}/${image_name_completed}.yml"
+du -a -k "${image_name_completed}" | awk '{ print "  \"" $2 "\": " $1}' | sort >> "${image_name_completed}/${image_name_completed}.yml"
+# TODO:
+#if [ "x${disk_file_cloned}" != "x" ]; then
+#    echo 'INFO: Collect dependencies of the image and store in the manifest file'
+#    echo "parents:" >> "${image_name_completed}/${image_name_completed}.yml"
+#    disk_to_process="${disk_file_cloned}"
+#    while [ "${disk_to_process}" ]; do
+#        parent_disk=$(grep '^parentFileNameHint=' "${disk_to_process}" | cut -d= -f2 | tr -d '"')
+#        [ "x${parent_disk}" != "x" ] || break
+#        parent_image=$(echo "${parent_disk}" | rev | cut -d/ -f2 | rev)
+#        echo "  - ${parent_image}" >> "${image_name_completed}/${image_name_completed}.yml"
+#        disk_to_process="$(echo "${parent_disk}" | sed 's|^../||')"
+#    done
+#fi
+
+echo 'INFO: Clean up the *.orig files in the completed image'
+rm -f "${image_name_completed}/"*.orig
+
+echo 'INFO: Run checksum of all the files in the archive'
+# MacOS doesn't have sha256sum command
+if ! command -v sha256sum > /dev/null; then alias sha256sum="shasum -a 256 -b"; fi
+sha256sum "${image_name_completed}"/* > "${image_name_completed}.sha256"
+mv "${image_name_completed}.sha256" "${image_name_completed}/"
+
+# Applying restrictive permissions to the image
+chmod 640 "${image_name_completed}"/*
+chmod 750 "${image_name_completed}"
+
+echo "INFO: Image post-process completed: ${image_name_completed}"

--- a/scripts/vncrecord.py
+++ b/scripts/vncrecord.py
@@ -67,16 +67,18 @@ class VNCRecord:
                     return
 
                 # Check for password
-                #     vmware-vmx: view the screen of the VM, connect via VNC with the password "nTtBphgk" to
+                # * "vmware-vmx: view the screen of the VM, connect via VNC with the password "nTtBphgk" to"
+                # * "tart-cli: If you want to view the screen of the VM, connect via VNC with the password "best-repair-gain-digital" to"
                 if 'connect via VNC with the password "' in line:
                     self._password = line.rsplit(' ', 2)[-2].strip('"')
 
                 # Check for host and port
-                #     vmware-vmx: vnc://127.0.0.1:5983
-                elif 'vmware-vmx: vnc://' in line:
+                # * "vmware-vmx: vnc://127.0.0.1:5983"
+                # * "tart-cli: vnc://127.0.0.1:60618"
+                elif ': vnc://' in line:
                     self._host, self._port = line.rsplit('vnc://', 1)[-1].split(':')
 
-            # Looking for the "Waiting" patterns
+            # Looking for the machine to boot patterns
             was_started = False
             try:
                 for line in self.tail(f):
@@ -85,11 +87,12 @@ class VNCRecord:
 
                     self._current_log = line.strip()
 
-                    if 'vmware-vmx: Waiting' in line and ' for boot...' in line:
+                    if ('Connected to the VNC' in line or 'Typing the commands over VNC...' in line) or \
+                            ('vmware-vmx: Waiting' in line and ' for boot...' in line):
                         self.startRecording()
                         was_started = True
-                    elif 'vmware-vmx: Gracefully halting virtual machine...' in line or \
-                            'vmware-vmx: Stopping virtual machine' in line:
+                    elif ': Gracefully halting virtual machine...' in line or \
+                            ': Stopping virtual machine' in line or ': Gracefully shutting down the VM' in line:
                         break
 
                     if was_started and not self._is_recording:

--- a/specs/tart/macos1306arm.yml
+++ b/specs/tart/macos1306arm.yml
@@ -1,0 +1,93 @@
+---
+# WARNING: Uses pre-cached python so make sure it's available in playbook/files/mac
+min_packer_version: 1.8.7
+variables:
+  # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
+  image_name: image
+  out_full_path: "{{ env `PWD` }}/out"
+  aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
+  username: packer
+  password: packer
+
+  ipsw_full_path: "{{ user `bait_path` }}/init/iso/UniversalMac_13.6_22G120_Restore.ipsw"
+
+builders:
+  - type: tart-cli
+    vm_name: "{{ user `image_name` }}"
+    from_ipsw: "{{ user `ipsw_full_path` }}"
+    cpu_count: 4
+    memory_gb: 8
+    disk_size_gb: 200
+    headless: true
+    run_extra_args:
+      - --net-host  # Using softnet host network in softnet to block global internet access
+    create_grace_time: 30s  # Workaround for Virtualization.Framework's installation process not completing in time
+    boot_wait: 30s  # Till the first screen
+    boot_command:
+      - <spacebar><wait5s>  # Intro with "hello, hola, bonjour, ..."
+
+      - <enter><wait10s>  # Selecting default "English" language and next
+      - United States<leftShiftOn><tab><leftShiftOff><spacebar><wait2s>  # Select country and next button
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait2s>  # Select keyboard locale and next button
+
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait2s>  # Skip accessibility
+      - <down><leftShiftOn><tab><leftShiftOff><spacebar><wait><enter><wait10s>  # Computer is not connected to internet and confirm
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait5s>  # Data privacy info and continue
+      - <tab><wait><tab><wait><tab><wait><spacebar><wait5s>  # Migration Assistant -> not now and continue
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait2s><tab><wait><spacebar><wait5s>  # Terms and Conditions --> Agree
+
+      - "{{ user `username` }}<tab>"  # Enter username
+      - <wait5s><tab><wait5s>  # Skip account name as the same as username
+      - "{{ user `password` }}<tab><wait5s>{{ user `password` }}<tab>"  # Set user password and verify
+      - <tab><tab><spacebar><wait20s>  # Click continue to create user account
+
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait5s><enter><wait5s>  # Skip enabling of location service and confirm in popup
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait5s>  # Use default time zone
+      - <tab><spacebar><leftShiftOn><wait1s><tab><leftShiftOff><spacebar><wait5s>  # Do not share analytics with Apple and continue
+      - <tab><spacebar><wait5s>  # Setup Screen Time later
+      - <tab><spacebar><leftShiftOn><tab><leftShiftOff><spacebar><wait5s>  # Disabling Siri and continue
+      - <leftShiftOn><tab><leftShiftOff><spacebar><wait1m>  # Leave default look and go to the desktop
+
+      # Enable remote access (SSH) with full disk access
+      - <leftAltOn><spacebar><leftAltOff><wait>system settings<enter><wait20s>  # Run system settings through spotlight
+      - <leftAltOn>f<leftAltOff>remote login<wait><enter><wait><down>  # Going into remote login popup
+      - <leftAltOn><f5><leftAltOff><wait15s><enter><wait10s>  # Enable VoiceOver
+      - <tab><spacebar><wait><enter><wait2s>  # Enable full disk access for remote users and press done
+      - <tab><tab><tab><tab><tab><tab><tab><wait><spacebar><wait5s>  # Go to remote login switch and toggle it
+      - <leftAltOn><f5><leftAltOff><wait2s>  # Disable VoiceOver
+      - <LeftAltOn>w<leftAltOff>  # Exit the system preferences
+    ssh_username: "{{ user `username` }}"
+    ssh_password: "{{ user `password` }}"
+    ssh_proxy_host: 127.0.0.1  # Local proxy in order to bypass VPN routing
+    ssh_proxy_port: "{{ user `aquarium_bait_proxy_port` }}"
+    ssh_timeout: 120s
+    ssh_read_write_timeout: 10s
+    ssh_wait_timeout: 2m
+    http_directory: playbooks/files
+
+provisioners:
+  # MacOS >=12.3 get rid of python2 - so we need to install python3 to run ansible
+  - type: shell
+    inline:
+      - curl -o /tmp/python.pkg "$PACKER_HTTP_ADDR/mac/python-3.10.4-macos11.pkg"
+      - echo '{{ user `password` }}' | sudo -S installer -pkg /tmp/python.pkg -target /
+
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/base_image.yml"
+    user: "{{ user `username` }}"
+    # Use python3 installed before instead of the default not working one (/usr/bin/python3)
+    # due to not installed developer tools and absent of any built-in python.
+    # Using inventory here because extra_arguments are working for localhost (vncdo) too.
+    inventory_file_template: >
+      {{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }}
+      ansible_python_interpreter=/usr/local/bin/python3
+    extra_arguments:
+      - -e
+      - ansible_sudo_pass={{ user `password` }}
+
+    # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
+    # which causes issues while running on OpenSSH client >9
+    use_sftp: true
+    sftp_command: /usr/libexec/sftp-server -e

--- a/specs/tart/macos1306arm/ci.yml
+++ b/specs/tart/macos1306arm/ci.yml
@@ -1,0 +1,63 @@
+---
+# WARNING: Uses pre-cached python so make sure it's available in playbook/files/mac
+min_packer_version: 1.8.7
+variables:
+  # All the variables are set by the build_image.sh script based on the path
+  bait_path: .
+  image_name: image
+  parent_name: parent_image
+  parent_version: parent_version
+  out_full_path: "{{ env `PWD` }}/out"
+  aquarium_bait_proxy_port: null  # Local proxy port to bypass VPN routing
+  username: packer
+  password: packer
+
+builders:
+  - type: tart-cli
+    vm_name: "{{ user `image_name` }}"
+    vm_base_name: "{{ user `parent_name` }}-{{ user `parent_version` }}"
+    cpu_count: 4
+    memory_gb: 8
+    disk_size_gb: 200
+    headless: true
+    run_extra_args:
+      - --net-host  # Using softnet host network in softnet to block global internet access
+    create_grace_time: 30s  # Workaround for Virtualization.Framework's installation process not completing in time
+    boot_wait: 30s  # Till the first screen
+
+    ssh_username: "{{ user `username` }}"
+    ssh_password: "{{ user `password` }}"
+    ssh_proxy_host: 127.0.0.1  # Local proxy in order to bypass VPN routing
+    ssh_proxy_port: "{{ user `aquarium_bait_proxy_port` }}"
+    ssh_timeout: 120s
+    ssh_read_write_timeout: 10s
+    ssh_wait_timeout: 2m
+
+provisioners:
+  - type: ansible
+    command: "{{ user `bait_path` }}/scripts/run_ansible.sh"
+    playbook_file: "{{ user `bait_path` }}/playbooks/ci_image.yml"
+    user: "{{ user `username` }}"
+    # Use python3 installed before instead of the default not working one (/usr/bin/python3)
+    # due to not installed developer tools and absent of any built-in python.
+    # Using inventory here because extra_arguments are working for localhost (vncdo) too.
+    inventory_file_template: >
+      {{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }}
+      ansible_python_interpreter=/usr/local/bin/python3
+    extra_arguments:
+      - -e
+      - ansible_sudo_pass={{ user `password` }}
+      - -e
+      - jre_extract_path=/opt/srv/jre
+      - -e
+      - jenkins_agent_ui=true
+      # Using arm package for jre
+      - -e
+      - jre_mac_download_url={% print jre_mac_arm_download_url %}
+      - -e
+      - jre_mac_download_sum={% print jre_mac_arm_download_sum %}
+
+    # By default packer uses `/usr/bin/sftp-server -e` which not exist on macos,
+    # which causes issues while running on OpenSSH client >9
+    use_sftp: true
+    sftp_command: /usr/libexec/sftp-server -e


### PR DESCRIPTION
Adds initial support for Tart macos + ci builder.

TODO: Packaging - in theory the images produced by Tart are not much different from typical Virtualization.Framework, so potentially could be running on other runners (like https://github.com/Code-Hex/vz/blob/main/example/macOS/main.go) and even with optimized Disk subsystem - I saw there a way to attach fd instead of file in the mac VF docs (right now it weights the size of disk, even if not completely used)...


## Related Issue

fixes: #46 

## Motivation and Context

There is a hurt to build images on new macs, so tart is a good option to do that.

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

