### PR TITLE
Ensure the local download directory will be created

### DIFF
--- a/playbooks/roles/download/tasks/linux.yml
+++ b/playbooks/roles/download/tasks/linux.yml
@@ -5,20 +5,29 @@
     '{{ download_result_var }}': '{% if inventory_hostname == "localhost" %}{{ playbook_dir }}/files/{{ download_lin_dir }}{% else %}{{ download_lin_tmp }}{% endif %}/{{ download_url | basename }}'
     download_local_path: '{{ playbook_dir }}/files/{{ download_lin_dir }}/{{ download_url | basename }}'
 
-- name: Create download directory
+- name: Create target download directory
   file:
     path: '{{ download_lin_tmp }}'
     state: directory
 
-- name: Download {{ download_url }} binary and verify checksum
+- name: Download file to local host
   when: not lookup('fileglob', download_local_path, errors='ignore')
-  delegate_to: localhost
-  get_url:
-    url: '{{ download_url }}'
-    headers: '{{ download_headers }}'
-    dest: '{{ download_local_path }}'
-    mode: '0440'
-    checksum: '{{ download_sum|default(omit) }}'
+  block:
+    # The local directory could be complicated so worth to make sure it exists
+    - name: Create local download directory
+      delegate_to: localhost
+      file:
+        path: '{{ download_local_path | dirname }}'
+        state: directory
+
+    - name: Download {{ download_url }} binary and verify checksum
+      delegate_to: localhost
+      get_url:
+        url: '{{ download_url }}'
+        headers: '{{ download_headers }}'
+        dest: '{{ download_local_path }}'
+        mode: '0440'
+        checksum: '{{ download_sum|default(omit) }}'
 
 # Copy operation is not really needed if we have the local connection and src path = dest path
 # Also it allows to save RAM on target system, big file copies for some reason are memory hungry

--- a/playbooks/roles/download/tasks/macos.yml
+++ b/playbooks/roles/download/tasks/macos.yml
@@ -5,20 +5,30 @@
     '{{ download_result_var }}': '{% if inventory_hostname == "localhost" %}{{ playbook_dir }}/files/{{ download_mac_dir }}{% else %}{{ download_mac_tmp }}{% endif %}/{{ download_url | basename }}'
     download_local_path: '{{ playbook_dir }}/files/{{ download_mac_dir }}/{{ download_url | basename }}'
 
-- name: Create download directory
+- name: Create target download directory
   file:
     path: '{{ download_mac_tmp }}'
     state: directory
 
-- name: Download {{ download_url }} binary and verify checksum
+- name: Download file to local host
   when: not lookup('fileglob', download_local_path, errors='ignore')
-  delegate_to: localhost
-  get_url:
-    url: '{{ download_url }}'
-    headers: '{{ download_headers }}'
-    dest: '{{ download_local_path }}'
-    mode: '0440'
-    checksum: '{{ download_sum|default(omit) }}'
+  block:
+    # The local directory could be complicated so worth to make sure it exists
+    - name: Create local download directory
+      delegate_to: localhost
+      file:
+        path: '{{ download_local_path | dirname }}'
+        state: directory
+
+    - name: Download {{ download_url }} binary and verify checksum
+      when: not lookup('fileglob', download_local_path, errors='ignore')
+      delegate_to: localhost
+      get_url:
+        url: '{{ download_url }}'
+        headers: '{{ download_headers }}'
+        dest: '{{ download_local_path }}'
+        mode: '0440'
+        checksum: '{{ download_sum|default(omit) }}'
 
 # Copy operation is not really needed if we have the local connection and src path = dest path
 # Also it allows to save RAM on target system, big file copies for some reason are memory hungry

--- a/playbooks/roles/download/tasks/windows.yml
+++ b/playbooks/roles/download/tasks/windows.yml
@@ -5,20 +5,30 @@
     '{{ download_result_var }}': '{{ download_win_tmp }}\{{ download_url | basename }}'
     download_local_path: '{{ playbook_dir }}/files/{{ download_win_dir }}/{{ download_url | basename }}'
 
-- name: Create download directory
+- name: Create target download directory
   win_file:
     path: '{{ download_win_tmp }}'
     state: directory
 
-- name: Download {{ download_url }} binary and verify checksum
+- name: Download file to local host
   when: not lookup('fileglob', download_local_path, errors='ignore')
-  delegate_to: localhost
-  get_url:
-    url: '{{ download_url }}'
-    headers: '{{ download_headers }}'
-    dest: '{{ download_local_path }}'
-    mode: '0440'
-    checksum: '{{ download_sum|default(omit) }}'
+  block:
+    # The local directory could be complicated so worth to make sure it exists
+    - name: Create local download directory
+      delegate_to: localhost
+      file:
+        path: '{{ download_local_path | dirname }}'
+        state: directory
+
+    - name: Download {{ download_url }} binary and verify checksum
+      when: not lookup('fileglob', download_local_path, errors='ignore')
+      delegate_to: localhost
+      get_url:
+        url: '{{ download_url }}'
+        headers: '{{ download_headers }}'
+        dest: '{{ download_local_path }}'
+        mode: '0440'
+        checksum: '{{ download_sum|default(omit) }}'
 
 # Win task is used only for win remote so no need additional checks here
 - name: Push archive {{ download_local_path }} to target {{ vars[download_result_var] }} from the localhost files


### PR DESCRIPTION
Found that if we specify the download_*_dir with more complicated path then just platform (like in rosetta role) - the local directory will not be properly created. So this fix ensures local dir exists before requesting the download.

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

