### PR TITLE
Small fix for docker diskmount should not install scripts there

### DIFF
--- a/playbooks/roles/diskmount/tasks/main.yml
+++ b/playbooks/roles/diskmount/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Execute on Linux
   include_tasks: linux.yml
-  when: ansible_system == 'Linux'
+  when: ansible_system == 'Linux' and ansible_service_mgr == 'systemd'
 
 - name: Execute on MacOS
   include_tasks: macos.yml


### PR DESCRIPTION
Found that docker build was harmed by the last changes, so restored the logic by checking if systemd is installed on the system before apply the diskmount units & scripts steps.

## Related Issue

#57 

## Motivation and Context

Everything should work well

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

