### PR TITLE
A conflict in linux formatall ws label and other fixes

### DIFF
--- a/playbooks/roles/diskmount/files/lin/formatall.sh
+++ b/playbooks/roles/diskmount/files/lin/formatall.sh
@@ -3,6 +3,10 @@
 
 echo "Started formatall at $(date "+%y.%m.%d %H:%M:%S")"
 
+# Check the ws labels to start counter properly, otherwise we will see conflicts
+ws_labels_num=$(find /dev/disk/by-label -mindepth 1 -name 'ws*' | wc -l)
+[ "$ws_labels_num" -eq 0 ] || counter=$ws_labels_num
+
 # List disks without loop devices
 disks=$(lsblk --list --noheadings --nodeps --output PATH | sort | grep -v '^/dev/loop')
 

--- a/playbooks/roles/diskmount/files/lin/warmup.sh
+++ b/playbooks/roles/diskmount/files/lin/warmup.sh
@@ -20,8 +20,8 @@ for i in $(seq 1 20); do
         # Minimum disk warmup usage is 32MB
         [ "$usage" -gt 32 ] || continue
 
-        echo "Warmup: $label ($disk, ${usage}MB used)..."
-        fio --filename "$disk" --rw read --bs 1M --iodepth 32 --size "${usage}M" --ioengine libaio --direct 1 --name warmup_$uuid &
+        echo "Warmup: $label $uuid ($disk, ${usage}MiB used)..."
+        fio --filename "$disk" --rw read --bs 1Mi --iodepth 32 --size "${usage}Mi" --ioengine libaio --direct 1 --name warmup_$uuid --output "/var/log/warmup_$uuid.log" &
 
         # Save the volume is warmed up
         date > "/tmp/warmup_$uuid.txt"
@@ -29,5 +29,8 @@ for i in $(seq 1 20); do
 
     sleep $i
 done
+
+# Waiting for the running background jobs before wrapping up
+wait $(jobs -p)
 
 echo "Ended warmup at $(date "+%y.%m.%d %H:%M:%S")"

--- a/playbooks/roles/diskmount/files/mac/mountall.sh
+++ b/playbooks/roles/diskmount/files/mac/mountall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Mounts all the available volumes on external disks
+# Mounts all the available volumes on internal & external disks
 
 echo "Started mountall at $(date "+%y.%m.%d %H:%M:%S")"
 

--- a/playbooks/roles/diskmount/files/mac/warmup.sh
+++ b/playbooks/roles/diskmount/files/mac/warmup.sh
@@ -57,4 +57,7 @@ done
 # Cleanup root ssh keys when was used
 [ "x$root_keys_used" = "x" ] || rm -rf /var/root/.ssh
 
+# Waiting for the running background jobs before wrapping up
+wait $(jobs -p)
+
 echo "Ended warmup at $(date "+%y.%m.%d %H:%M:%S")"

--- a/playbooks/roles/diskmount/files/win/warmup.ps1
+++ b/playbooks/roles/diskmount/files/win/warmup.ps1
@@ -1,22 +1,32 @@
 #!powershell
 # Warmup by multithread reading the used disk space
 
+# Waiting for the disks population
+$wait_sec = 50
+while (($wait_sec--) -gt 0) {
+    $disks_count = (Get-PhysicalDisk | Get-Disk | Get-Partition | Where-Object DriveLetter).Count
+    if ($disks_count -gt 1) {
+        break
+    }
+    echo ("Waiting for disks: " + $disks_count)
+    Start-sleep -seconds 1
+}
+
 echo ('Started warmup at ' + (Get-Date -Format "yy.MM.dd HH:mm:ss"))
 
-$fio_started = false
+$procs = @()
 Get-PhysicalDisk | ForEach-Object {
     # Getting drive letter where disk is mounted
     $driveletter = ($_ | Get-Disk | Get-Partition | Where-Object DriveLetter).DriveLetter
     if( $driveletter -ne 'C' ) {
         $usage = [Math]::Ceiling((Get-PSDrive $driveletter).Used / 1024 / 1024)
-        echo ("Warmup Disk: " + $driveletter + " (" + $usage + "MB used)")
-        Start-Process -NoNewWindow "C:\util\fio\fio.exe" ("--filename \\.\PHYSICALDRIVE" + $_.DeviceId + " --rw read --bs 1M --iodepth 32 --size " + $usage + "M --direct 1 --name warmup_" + $_.DeviceId)
+        echo ("Warmup Disk: " + $driveletter + " " + $_.DeviceId + " (" + $usage + "MiB used)")
+        $procs += $(Start-Process -NoNewWindow -PassThru "C:\util\fio\fio.exe" -ArgumentList ("--thread --filename \\.\PHYSICALDRIVE" + $_.DeviceId + " --rw read --bs 128Ki --iodepth 32 --size " + $usage + "Mi --direct 1 --name warmup_" + $_.DeviceId + " --output C:\tmp\warmup_" + $_.DeviceId + ".log"))
         $fio_started = true
     }
 }
 
-if( $fio_started ) {
-    Wait-Process fio
-}
+echo "Waiting FIO processes to complete..."
+$procs | Wait-Process
 
 echo ('Ended warmup at ' + (Get-Date -Format "yy.MM.dd HH:mm:ss"))

--- a/playbooks/roles/jenkins_agent/tasks/linux.yml
+++ b/playbooks/roles/jenkins_agent/tasks/linux.yml
@@ -8,9 +8,11 @@
 - name: Add user jenkins with group jenkins
   become: true
   user:
+    uid: 5001
     name: jenkins
     group: jenkins
-    uid: 5001
+    groups:
+      - systemd-journal  # Allow to read journals to collect system info
     comment: Jenkins
 
 - name: Install tools required by jenkins_agent.sh script

--- a/upload_file.sh
+++ b/upload_file.sh
@@ -11,15 +11,23 @@
 
 # Upload all the following files to the specific URL
 # Usage:
-#   ./upload_file.sh <login:token> <UPLOAD_URL> [path/to/file] [...]
+#   ./upload_file.sh [login:token] <UPLOAD_URL> [path/to/file] [...]
 
-[ "$ARTIFACT_STORAGE_AUTH" ] || ARTIFACT_STORAGE_AUTH="$1"
+if [ -z "$ARTIFACT_STORAGE_AUTH" ]; then
+    ARTIFACT_STORAGE_AUTH="$1"
+    shift
+fi
 
-UPLOAD_URL="$2"
+UPLOAD_URL="$1"
+shift
 
 for f in "$@"; do
-    [ -f "$f" ] || continue
+    if [ ! -f "$f" ]; then
+        echo "WARNING: Skipping $f - does not exist"
+        continue
+    fi
     name=$(basename "$f")
+
     echo "INFO: Processing $f"
 
     echo "INFO:  calcuating checksum ..."
@@ -36,7 +44,7 @@ for f in "$@"; do
     echo
     echo "INFO:  - name: \"$name\""
     echo "INFO:    url: \"$url\""
-    echo "INFO:    checksum: \"sha256:$checksum\""
+    echo "INFO:    sum: \"sha256:$checksum\""
     echo
 done
 

--- a/upload_file.sh
+++ b/upload_file.sh
@@ -16,7 +16,6 @@
 [ "$ARTIFACT_STORAGE_AUTH" ] || ARTIFACT_STORAGE_AUTH="$1"
 
 UPLOAD_URL="$2"
-FILE_PATH="$3"
 
 for f in "$@"; do
     [ -f "$f" ] || continue
@@ -26,11 +25,11 @@ for f in "$@"; do
     echo "INFO:  calcuating checksum ..."
     # MacOS doesn't have sha256sum command
     if ! command -v sha256sum > /dev/null; then alias sha256sum="shasum -a 256 -b"; fi
-    checksum=$(sha256sum "$FILE_PATH" | cut -d' ' -f1)
+    checksum=$(sha256sum "$f" | cut -d' ' -f1)
 
     url="$UPLOAD_URL/$name"
     echo "INFO:  uploading to $url ..."
-    curl --progress-bar -u "$ARTIFACT_STORAGE_AUTH" -X PUT -H "X-Checksum-Sha256: $checksum" -T "$FILE_PATH" "$url" | tee /dev/null
+    curl --progress-bar -u "$ARTIFACT_STORAGE_AUTH" -X PUT -H "X-Checksum-Sha256: $checksum" -T "$f" "$url" | tee /dev/null
 
     echo
     echo "INFO:  upload complete:"

--- a/upload_image.sh
+++ b/upload_image.sh
@@ -13,12 +13,17 @@
 # Usage:
 #   ./upload_image.sh [login:token] <out/type/image.tar.xz> [...]
 
-[ "$ARTIFACT_STORAGE_AUTH" ] || ARTIFACT_STORAGE_AUTH=$1
+if [ -z "$ARTIFACT_STORAGE_AUTH" ]; then
+    ARTIFACT_STORAGE_AUTH="$1"
+    shift
+fi
 [ "$ARTIFACT_STORAGE_URL" ] || ARTIFACT_STORAGE_URL=https://artifact-storage/aquarium/image
 
 for path in "$@"; do
-    # Skipping non-file target
-    [ -f "${path}" ] || continue
+    if [ ! -f "$f" ]; then
+        echo "WARNING: Skipping $f - does not exist"
+        continue
+    fi
 
     name=$(basename "$path" | rev | cut -d- -f2- | rev)
     type=$(basename "$(dirname "$path")")
@@ -45,7 +50,7 @@ for path in "$@"; do
     echo
     echo "INFO:  - name: \"$name\""
     echo "INFO:    url: \"$url\""
-    echo "INFO:    checksum: \"sha256:$checksum\""
+    echo "INFO:    sum: \"sha256:$checksum\""
     echo
 done
 

--- a/upload_iso.sh
+++ b/upload_iso.sh
@@ -13,13 +13,16 @@
 # Usage:
 #   ./upload_image.sh [login:token] <iso/cd_dvd.iso> [artifact_path]
 
-[ "$ARTIFACT_STORAGE_AUTH" ] || ARTIFACT_STORAGE_AUTH="$1"
+if [ -z "$ARTIFACT_STORAGE_AUTH" ]; then
+    ARTIFACT_STORAGE_AUTH="$1"
+    shift
+fi
 [ "$ARTIFACT_STORAGE_URL" ] || ARTIFACT_STORAGE_URL=https://artifact-storage/aquarium/installer
 
-FILE_PATH="$2"
+FILE_PATH="$1"
 name=$(basename "$FILE_PATH" | rev | cut -d- -f2- | rev)
 
-[ "$ARTIFACT_PATH" ] || ARTIFACT_PATH="$3"
+[ "$ARTIFACT_PATH" ] || ARTIFACT_PATH="$2"
 [ "$ARTIFACT_PATH" ] || ARTIFACT_PATH="$name/$(basename "$FILE_PATH")"
 
 # Skipping non-file target
@@ -48,7 +51,7 @@ echo "INFO:  upload complete:"
 echo
 echo "INFO:  - name: \"$name\""
 echo "INFO:    url: \"$url\""
-echo "INFO:    checksum: \"sha256:$checksum\""
+echo "INFO:    sum: \"sha256:$checksum\""
 echo
 
 echo "INFO: Upload operation done"


### PR DESCRIPTION
Found a couple of nasty bugs in the disk init scripts and fixed them.

* formatall in linux can easily create another ws to the existing one and mount it over the same mountpoint which leads to empty workspace instead of cached one
* warmup scripts:
   * used base 10 instead of base 2 for bytes size
   * windows could skip the disks because they were not populated at the time and terminate the running fio processes because did not wait properly for them
   * fio now outputs to separated file to keep an eye on warmed up disks results
* added jenkins user on linux to be in journal group to read logs from the system
* quick fix for file upload due to obvious bug in the logic

## Related Issue

#57 

## Motivation and Context

Conflicts in disks mounts are bad

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

