### PR TITLE
Fixes for jenkins agent and xcode simulators

### DIFF
--- a/playbooks/roles/jenkins_agent/tasks/linux.yml
+++ b/playbooks/roles/jenkins_agent/tasks/linux.yml
@@ -44,6 +44,13 @@
 
 - when: ansible_service_mgr == 'systemd'
   block:
+    - name: Add user jenkins to systemd-journal group
+      become: true
+      user:
+        name: jenkins
+        groups:
+          - systemd-journal  # Allow to read journals to collect system info
+
     - name: Add jenkins-agent systemd service
       become: true
       template:

--- a/playbooks/roles/xcode/defaults/main.yml
+++ b/playbooks/roles/xcode/defaults/main.yml
@@ -11,7 +11,10 @@ xcode_cmd_download_sum: '{{ xcode_version_122_cmd_mac_download_sum }}'
 # List of the simulator runtimes (platform/version) need to be installed, usually: iOS, watchOS, tvOS, visionOS
 xcode_simruntime_install: []
 #   - platform: iOS  # To install default version from the `xcodebuild -showsdks`
+#     check:
+#       - iPad Air   # Make sure this specific simruntime is installed
 #   - platform: iOS
-#     version: 10.2
+#     version: 10.2  # Specify version of the OS to install
+#     # Will skip validation the specific simruntimes
 xcode_simruntime_download_prefix: https://artifact-storage/aquarium/files/mac/rosetta
 xcode_simruntime_default_rel: '{{ platform|default("") }}_{{ version|default("") }}_Simulator_Runtime.dmg'

--- a/playbooks/roles/xcode/tasks/main.yml
+++ b/playbooks/roles/xcode/tasks/main.yml
@@ -13,3 +13,4 @@
   vars:
     simruntime_platform: '{{ item.platform }}'
     simruntime_version: '{{ item.version|default("") }}'
+    simruntime_check: '{{ item.check|default([]) }}'

--- a/playbooks/roles/xcode/tasks/simruntime.yml
+++ b/playbooks/roles/xcode/tasks/simruntime.yml
@@ -10,8 +10,8 @@
       set_fact:
         # This expression looks for "Simulator - <simruntime_platform>" and it's item version to get the default version value
         simruntime_version2: >-
-          {{ (reg_xcodebuild_showsdks.stdout | from_json | flatten | selectattr('displayName', 'regex', '^Simulator - '+simruntime_platform) | first).platformVersion
-          | default('default simulator not found') }}
+          {{ (reg_xcodebuild_showsdks.stdout | from_json | flatten | selectattr('displayName', 'regex', '^Simulator - '+(simruntime_platform|regex_escape))
+          | first).platformVersion | default('default simulator not found') }}
 
 - name: Download simulator runtime to the environment
   include_role:
@@ -24,3 +24,31 @@
 - name: Install simulator runtime from the dmg
   become: true
   command: xcrun simctl runtime add '{{ download_path }}'
+
+# This check is also a part of init process - if we will not call it, mac will wait for ~3 min and
+# return just the host as available runtime, which will be incorrect by all means.
+- name: Getting list of the available simruntimes
+  command: xcrun xcdevice list
+  register: reg_xcrun_devlist
+
+- name: Validating simulator runtime is installed
+  when: simruntime_check|default([])|length > 0
+  block:
+    - name: Finding check simruntimes version
+      with_indexed_items: '{{ simruntime_check }}'
+      # noqa var-naming
+      set_fact:
+        # This expression will try to find the simruntime version by the provided item to check
+        "{{ 'simruntime_check_version_'+(item.0|string) }}": >-
+          {{ ((reg_xcrun_devlist.stdout | from_json | flatten | selectattr('modelName', 'regex', '^'+(item.1 | regex_escape))
+          | first).operatingSystemVersion | default('')).split() | first | default('') }}
+
+    - name: Listing all the versions
+      set_fact:
+        simruntime_check_versions: >-
+          {% for key in vars %}{% if key.startswith('simruntime_check_version_') %}{{ vars[key] }} {% endif %}{% endfor %}
+
+    - name: Fail if no simruntime checks was found in the list
+      when: simruntime_check_versions != ( ((simruntime_version2 | default(simruntime_version)) + " ") * simruntime_check|length )
+      fail:
+        msg: Incorrect versions for checked simruntime {{ simruntime_check_versions }} != {{ ( ((simruntime_version2 | default(simruntime_version)) + " ") * (simruntime_check|length) ) }}


### PR DESCRIPTION
Found that xcode shows just the host simruntime available if it was not listed before - so we just need to list (and validate) the simruntimes in advance.

Also it has a fix for introduced docker image build issue where it is unable to setup jenkins user due to unavailability of systemd. 

## Related Issue

#53 

## Motivation and Context

Better handling of macos xcode images

## How Has This Been Tested?

Manually via VMX

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

