### PR TITLE
Missed the outer include loop item conflict, so fixed it

### DIFF
--- a/playbooks/roles/xcode/tasks/main.yml
+++ b/playbooks/roles/xcode/tasks/main.yml
@@ -9,8 +9,10 @@
 # Going through the simruntime installs list
 - name: Install simruntimes
   with_items: "{{ xcode_simruntime_install }}"
+  loop_control:
+    loop_var: ext_item
   include_tasks: simruntime.yml
   vars:
-    simruntime_platform: '{{ item.platform }}'
-    simruntime_version: '{{ item.version|default("") }}'
-    simruntime_check: '{{ item.check|default([]) }}'
+    simruntime_platform: '{{ ext_item.platform }}'
+    simruntime_version: '{{ ext_item.version|default("") }}'
+    simruntime_check: '{{ ext_item.check|default([]) }}'


### PR DESCRIPTION
The outer loop in main.yml is affecting the simruntime.yml validation loop. Seems during my previous VMX tests that was not triggered, because I used incorrect params and missed to test this particular case...

## Related Issue

#60 

## Motivation and Context

Bugs everywhere!)

## How Has This Been Tested?

Manually VMX

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

