### PR TITLE
Simplified the process of checking jenkins is available by downloading agent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,8 +153,9 @@ jobs:
           export BAIT_SPEC_CHANGE='{"provisioners":[{"playbook_file":"{{ user `bait_path` }}/playbooks/bait_validate.yml"}]}'
 
           # Find all the specs and sort them to build them sequentially (parent-child)
-          echo "Build jobs to process: $(find ./specs/docker -name '*.yml' | wc -l)"
-          for spec in $(find ./specs/docker -name '*.yml' | sort); do
+          # The colima is very slow, so building just first 5 specs
+          echo "Build jobs to process: $(find ./specs/docker -name '*.yml' | head -n 5 | wc -l)"
+          for spec in $(find ./specs/docker -name '*.yml' | sort | head -n 5); do
             echo "::group::./build_image.sh ${spec}"
             ./build_image.sh "${spec}" | tee build.log
 

--- a/playbooks/roles/jenkins_agent/files/lin/jenkins_agent.sh
+++ b/playbooks/roles/jenkins_agent/files/lin/jenkins_agent.sh
@@ -110,14 +110,11 @@ until cd "${ws_path}"; do
     sleep 5
 done
 
-# Wait for jenkins response
-until curl -s -o /dev/null -w '%{http_code}' ${curl_insecure} "${JENKINS_URL}" | grep -s '403\|200' > /dev/null; do
+# Download the agent jar
+until [ "x$(curl -sSLo agent.jar -w '%{http_code}' ${curl_insecure} "${JENKINS_URL}/jnlpJars/agent.jar")" = 'x200' ]; do
     echo "Wait for '${JENKINS_URL}' jenkins response..."
     sleep 5
 done
-
-# Download the agent jar and connect to jenkins
-curl -sSLo agent.jar ${curl_insecure} "${JENKINS_URL}/jnlpJars/agent.jar"
 
 # Run the agent once - we don't need it to restart due to dynamic nature of the agent
 echo "Running the Jenkins agent '${JENKINS_AGENT_NAME}'..."

--- a/playbooks/roles/jenkins_agent/files/mac/jenkins_agent.sh
+++ b/playbooks/roles/jenkins_agent/files/mac/jenkins_agent.sh
@@ -114,14 +114,11 @@ until cd "${ws_path}"; do
     sleep 5
 done
 
-# Wait for jenkins response
-until curl -s -o /dev/null -w '%{http_code}' ${curl_insecure} "${JENKINS_URL}" | grep -s '403\|200' > /dev/null; do
+# Download the agent jar
+until [ "x$(curl -sSLo agent.jar -w '%{http_code}' ${curl_insecure} "${JENKINS_URL}/jnlpJars/agent.jar")" = 'x200' ]; do
     echo "Wait for '${JENKINS_URL}' jenkins response..."
     sleep 5
 done
-
-# Download the agent jar and connect to jenkins
-curl -sSLo agent.jar ${curl_insecure} "${JENKINS_URL}/jnlpJars/agent.jar"
 
 # Run the agent once - we don't need it to restart due to dynamic nature of the agent
 echo "Running the Jenkins agent '${JENKINS_AGENT_NAME}'..."

--- a/playbooks/roles/jenkins_agent/files/win/jenkins_agent.ps1
+++ b/playbooks/roles/jenkins_agent/files/win/jenkins_agent.ps1
@@ -155,18 +155,20 @@ if( "${JENKINS_AGENT_WORKSPACE}" ) {
     }
 }
 
-# Wait for jenkins response
+# Download the agent jar
 While( $true ) {
-    $code = try { (Invoke-WebRequest "${JENKINS_URL}").StatusCode } catch { $_.Exception.Response.StatusCode.Value__ }
-    if( $code -eq 200 -or $code -eq 403 ) {
-        break
-    }
+    try {
+        Invoke-WebRequest "${JENKINS_URL}/jnlpJars/agent.jar" -OutFile agent.jar
+        if (Test-Path agent.jar) {
+            $fileSize = (Get-Item agent.jar).Length
+            if ($fileSize -gt 0) {
+                break
+            }
+        }
+    } catch {  }
     echo "Wait for '${JENKINS_URL}' jenkins response..."
     sleep 5
 }
-
-# Download the agent jar and connect to jenkins
-Invoke-WebRequest "${JENKINS_URL}/jnlpJars/agent.jar" -OutFile agent.jar
 
 # Run the agent once - we don't need it to restart due to dynamic nature of the agent
 echo "Running the Jenkins agent '${JENKINS_AGENT_NAME}'..."


### PR DESCRIPTION
Change simplifies logic of the jenkins agent startup script to validate jenkins availability by downloading the agent from it. If we have agent - that means we can continue and from there the agent itself will check that jenkins is fine or not.

Also it modifies the colima validation to limit to 5 specs - otherwise it's taking too long.

## Related Issue

Recently we found that in some jenkins configs windows agent script doesn't want to acknowledge controller, so this fix solving the issue.

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

