### PR TITLE
Locate `devenv.exe` using `vswhere`

### DIFF
--- a/playbooks/roles/visualstudio/tasks/vs.yml
+++ b/playbooks/roles/visualstudio/tasks/vs.yml
@@ -74,11 +74,11 @@
   register: reg_vs_install_result
   failed_when: reg_vs_install_result.rc not in [0, 3010]  # Describes reboot is needed
 
-# Locate devenv.exe path in registry to find the path to IDE directory
-- name: Locate VS path using registry
+# Locate devenv.exe path to find the path to IDE directory
+- name: Locate VS path using vswhere
   win_shell: >
-    (Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\devenv.exe'
-    -Name '(default)').Trim('"') | Split-Path | Split-Path | Split-Path
+    (& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+    /property productPath) | Split-Path | Split-Path | Split-Path
   register: reg_vs_path
 
 - name: Put the vs path to visualstudio_install_path variable


### PR DESCRIPTION
For some older versions of Visual Studio, the registry does not contain a path to `devenv.exe`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

The visual studio 17.4.4 installer I was working with in particular does not edit the registry.  From searching online, it seems Microsoft has been a bit inconsistent across releases as to what gets set where.

## Motivation and Context

Create a uniform way of locating the visual studio installation.

## How Has This Been Tested?

Local build success with vs1704.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

