### PR TITLE
Fixed issue with building native images on modern mac

### DIFF
--- a/scripts/run_postprocess_native.sh
+++ b/scripts/run_postprocess_native.sh
@@ -19,6 +19,13 @@ IMAGE_NAME=$(basename "${IMAGE_FULL_PATH}")
 
 root_dir="$PWD"
 
+if [ "x$(uname)" = "xDarwin" ]; then
+    # MacOS puts quarantine attribute on files after native unpacking, so removing it after the fact
+    echo 'INFO: Applying special quarantine fix for macos builder host'
+    chmod -R u+rw "${IMAGE_FULL_PATH}"
+    xattr -dr com.apple.quarantine "${IMAGE_FULL_PATH}"
+fi
+
 echo 'INFO: Pack the prepared environment as tar archive'
 cd "${IMAGE_FULL_PATH}"
 tar -cf "${IMAGE_FULL_PATH}.tar" *

--- a/upload_image.sh
+++ b/upload_image.sh
@@ -48,9 +48,9 @@ for path in "$@"; do
     echo
     echo "INFO:  upload complete:"
     echo
-    echo "INFO:  - name: \"$name\""
-    echo "INFO:    url: \"$url\""
-    echo "INFO:    sum: \"sha256:$checksum\""
+    echo "INFO:  - name: $name"
+    echo "INFO:    url: $url"
+    echo "INFO:    sum: sha256:$checksum"
     echo
 done
 


### PR DESCRIPTION
Apparently new mac versions doesn't like unpacking operations through ansible on anything, so marking almost anything as xattr quarantine. This fix prevents mac host to interfere in the building native images process and removes quarantine attr, which otherwise will prevent binaries from running on the target mac system.

## Related Issue

None

## Motivation and Context

Keeping the roof leakproof

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

