### PR TITLE
Don't exit cleanup when there are no parent images

### DIFF
--- a/scripts/run_postprocess_docker.sh
+++ b/scripts/run_postprocess_docker.sh
@@ -87,8 +87,7 @@ if [ $image_stage -gt 1 ]; then
             done
         fi
         if [ "x${parent_layers_removed}" = 'x' ]; then
-            echo "ERROR:   none parent layers was found to remove for ${parent_name}"
-            exit 1
+            echo "INFO:   none parent layers was found to remove for ${parent_name}"
         fi
     done
     echo 'INFO:   pack the image back to tar archive'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During Docker cleanup, don't error out if no parent layers are removed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

